### PR TITLE
Add support for dependency renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ The enabled features for a crate now are resolved at build time! That means you 
   build generation time since we can simply pass this set to `cargo metadata`. Feature selection during build time is
   out of scope for now.~~
 * No support for building and running tests, see [nixpkgs, issue 59177](https://github.com/NixOS/nixpkgs/issues/59177).
-* [Renamed crates](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml)
-  with an explicit `package` name don't work yet.
+* ~~Before 0.6.x: [Renamed crates](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml)
+  with an explicit `package` name don't work yet.~~
 * Since cargo exposes local paths in package IDs, the generated build file also contain them as part of an "opaque"
   ID. They are not interpreted as paths but maybe you do not want to expose local paths in there...
 * It does translates target strings to nix expressions. The support should be reasonable but probably not complete - please

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,7 +1,7 @@
 let nixpkgs = builtins.fetchTarball {
-    name = "nixos-unstable-2019-04-28";
-    url = https://github.com/nixos/nixpkgs/archive/a2e219ec879fe3de62e9204ad33efb5b67a4a324.tar.gz;
-    sha256 = "0bdr8ii6kc1rd4l5dnmqpb5ljh2wk47y75n9ibg2ddc62hi6jxq9";
+    name = "nixos-unstable-20190910";
+    url = https://github.com/nixos/nixpkgs/archive/a69a6c11176d6aa96ab7c8f7308be4b95206598e.tar.gz;
+    sha256 = "0m66fx9xfh91q6dch6q4ir80zr3iga6y902h83rb7swzaqn9gi7m";
 };
 
 in import nixpkgs

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -345,6 +345,7 @@ impl<'a> ResolvedDependencies<'a> {
                     .get(&normalized_package_name)
                     .map(|dependency| ResolvedDependency {
                         name: dependency.name.clone(),
+                        rename: dependency.rename.clone(),
                         package_id: d.id.clone(),
                         target: dependency
                             .target
@@ -362,6 +363,8 @@ impl<'a> ResolvedDependencies<'a> {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ResolvedDependency {
     pub name: String,
+    /// New name for the dependency if it is renamed.
+    pub rename: Option<String>,
     pub package_id: PackageId,
     /// The cfg expression for conditionally enabling the dependency (if any).
     /// Can also be a target "triplet".

--- a/templates/build.nix.tera
+++ b/templates/build.nix.tera
@@ -124,9 +124,13 @@ rec {
         {%- if crate.dependencies|length > 0 %}
         dependencies = {
         {%- for dependency in crate.dependencies %}
-          {%- if dependency.target or dependency.optional or not dependency.uses_default_features or dependency.features %}
+          {%- if dependency.target or dependency.optional or not dependency.uses_default_features or
+            dependency.features or dependency.rename %}
           {{dependency.name}} = {
             packageId = {{dependency.package_id}};
+            {%- if dependency.rename %}
+            rename = {{dependency.rename}};
+            {%- endif %}
             {%- if dependency.optional %}
             optional = true;
             {%- endif -%}

--- a/templates/nix/crate2nix/default.nix
+++ b/templates/nix/crate2nix/default.nix
@@ -84,7 +84,12 @@ rec {
                 dependencyDerivations buildByPackageId features (crateConfig.dependencies or {});
               buildDependencies =
                 dependencyDerivations buildByPackageId features (crateConfig.buildDependencies or {});
-          in buildRustCrate (crateConfig // { inherit features dependencies buildDependencies; });
+              dependenciesWithRenames =
+                lib.filterAttrs (n: v: v ? "rename")
+                  (crateConfig.buildDependencies or {} // crateConfig.dependencies or {});
+              crateRenames =
+                lib.mapAttrs (name: value: value.rename or name) dependenciesWithRenames;
+          in buildRustCrate (crateConfig // { inherit features dependencies buildDependencies crateRenames; });
     in buildByPackageId packageId;
 
   /* Returns the actual derivations for the given dependencies. */

--- a/tests/sample_projects.rs
+++ b/tests/sample_projects.rs
@@ -130,7 +130,6 @@ fn build_and_run_bin_with_lib_git_dep() {
 }
 
 #[test]
-#[ignore]
 fn build_and_run_bin_with_rerenamed_lib_dep() {
     let output = build_and_run(
         "sample_projects/bin_with_rerenamed_lib_dep/Cargo.toml",
@@ -140,7 +139,7 @@ fn build_and_run_bin_with_rerenamed_lib_dep() {
         &["default"],
     );
 
-    assert_eq!("Hello world from bin_with_rerenamed_lib_dep!\n", &output);
+    assert_eq!("Hello, bin_with_rerenamed_lib_dep!\n", &output);
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support for renamed dependencies. I have marked this as a draft PR, since it only works iff

https://github.com/NixOS/nixpkgs/pull/68296

gets merged. I will also update the PR later to add a test. This fixes #22.