### PR TITLE
Support passing the `ref` attribute to `fetchGit`

### DIFF
--- a/templates/build.nix.tera
+++ b/templates/build.nix.tera
@@ -89,6 +89,9 @@ rec {
         src = builtins.fetchGit {
           url = {{crate.source.Git.url}};
           rev = {{crate.source.Git.rev}};
+          {%- if crate.source.Git.ref %}
+          ref = {{ crate.source.Git.ref }}
+          {%- endif %}
         };
         {%- else %}
         # ERROR: Could not resolve source: {{crate.source | safe | json_encode()}}


### PR DESCRIPTION
When fetching a git repository it sometimes is requires to pass the
explicit git branch got `builtins.fetchGit` as it otherwise can't find
the right commit.

Passing the `ref` argument to the function helps in those situations.

Currently only the `branch` attribute of the git URLs is supported. Git
tags should usually also work but I have no reference how those look in
the cargo generated URLs.

Fixes #27

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kolloch/crate2nix/29)
<!-- Reviewable:end -->
