### PR TITLE
Handle special `../` case for path

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -268,7 +268,10 @@ impl ResolvedSource {
         } else {
             let path = diff_paths(package_path.as_ref(), &output_build_file_directory)
                 .unwrap_or_else(|| package_path.as_ref().to_path_buf());
-            if path.starts_with("../") {
+            if path == PathBuf::from("../") {
+                path.join(PathBuf::from("."))
+            }
+            else if path.starts_with("../") {
                 path
             } else {
                 PathBuf::from("./").join(path)


### PR DESCRIPTION
Nix doesn't parse `../` as a valid path it requires a trailing dot in
that case.

fixes #28