### PR TITLE
Support building crate2nix on hydra

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,5 @@
-{ pkgs? import ./nixpkgs.nix { config = {}; },
+{ nixpkgs? ./nixpkgs.nix,
+  pkgs? import nixpkgs { config = {}; },
   lib? pkgs.lib,
   cargo? pkgs.cargo,
   nix? pkgs.nix,

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,8 @@
+{ nixpkgs ? null, ... }@_args:
+with builtins;
+let
+  names = filter (n: _args.${n} != null) (attrNames _args);
+  args = listToAttrs (map (name: { inherit name; value = _args.${name}; }) names);in
+{
+  crate2nix = import ./default.nix args;
+}


### PR DESCRIPTION
This PR adds support to build `crate2nix` on a hydra instance by providing a `nixpkgs` input.
I run my own binary cache that is populated by an hydra instance. By adding a jobset I no longer have to build `crate2nix` on all my machines and in all my shell environments.