### PR TITLE
Permit overriding buildRustCrate arguments

### DIFF
--- a/templates/nix/crate2nix/default.nix
+++ b/templates/nix/crate2nix/default.nix
@@ -68,7 +68,9 @@ rec {
   /* A restricted overridable version of  buildRustCrateWithFeaturesImpl. */
   buildRustCrateWithFeatures = {packageId, features}:
     lib.makeOverridable
-      ({features}: buildRustCrateWithFeaturesImpl {inherit packageId features;})
+      (args@{features, ...}:
+        let buildRustCrateArgs = lib.filterAttrs (n: _: n != "features") args;
+        in (buildRustCrateWithFeaturesImpl {inherit packageId features;}).override buildRustCrateArgs)
       { inherit features; };
 
   /* Returns a buildRustCrate derivation for the given packageId and features. */


### PR DESCRIPTION
`buildRustCrateWithFeatures` makes its implementation overridable.
However in doing so, it hides the `override` function of `buildRustCrate`.

With this change attributes other than `features` are passed through to
`buildRustCrate`'s override, so that its arguments are overridable too.

This addresses #15.

---

@kolloch  I made this a draft PR to ask if this is something you would accept. If so, I'll add a test for this as well.