### PR TITLE
Handle overlapping target.cfg sections better

### DIFF
--- a/templates/build.nix.tera
+++ b/templates/build.nix.tera
@@ -127,7 +127,7 @@ rec {
         {%- if crate.dependencies|length > 0 %}
         dependencies = {
         {%- for dependency in crate.dependencies %}
-          {%- if dependency.target or dependency.optional or not dependency.uses_default_features or
+          {%- if dependency.targets|length > 0 or dependency.optional or not dependency.uses_default_features or
             dependency.features or dependency.rename %}
           {{dependency.name}} = {
             packageId = {{dependency.package_id}};
@@ -140,8 +140,8 @@ rec {
             {%- if not dependency.uses_default_features %}
             usesDefaultFeatures = false;
             {%- endif -%}
-            {%- if dependency.target %}
-            target = {{dependency.target | safe | cfg_to_nix_expr}};
+            {%- if dependency.targets|length > 0 %}
+            target = {{dependency.targets | safe | cfg_to_nix_expr}};
             {%- endif %}
             {%- if dependency.features %}
             features = [ {% for feature in dependency.features %}{{feature}} {% endfor %}];


### PR DESCRIPTION
Some packages (e.g. glutin) has the same package in multiple dependency
sections, for example (snippet with other dependencies cut out): 
```
[target.'cfg(target_os = "windows")'.dependencies]
glutin_egl_sys = { version = "0.1.3", path = "../glutin_egl_sys" }

[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
glutin_egl_sys = { version = "0.1.3", path = "../glutin_egl_sys" }
```

I messed around a bit and got it to work by extending `target` to `targets` in `ResolvedDependency`, and then combining the conditions with `CfgExpr::Any`. While I think that is strictly better than the current behaviour (which just ignores the second entry), it doesn't handle the cases where they have different features or renames, but that will require some design work.

I tested it locally on an Amethyst project, and it seems to work. If you're interested in merging some variant of this code I can add comments/tests.