### PR TITLE
Add fuchsia as an (unsupported) target

### DIFF
--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -10,6 +10,7 @@ rec {
   target = {
       unix = true;
       windows = false;
+      fuchsia = true;
       # We don't support tests yet, so this is true for now.
       test = false;
 


### PR DESCRIPTION
Some crates (eg getrandom) generate a `target."fuschia"` expression, which currently throws an error.