### PR TITLE
Fix README: stable -> unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ get prebuilt binaries for linux.
 Similarly, you can either
 
 ```bash
-# Install the stable version to your user env (with shell completions):
+# Install the unstable version to your user env (with shell completions):
 nix-env -i -f https://github.com/kolloch/crate2nix/tarball/master
 ```
 


### PR DESCRIPTION
I guess this from a copy/paste. Maybe you prefer 'master' or something else instead of 'unstable'.