### PR TITLE
Canonicalize the src_path at buildTarget creation

### DIFF
--- a/crate2nix/src/resolve.rs
+++ b/crate2nix/src/resolve.rs
@@ -143,7 +143,7 @@ impl BuildTarget {
     pub fn new(target: &Target, package_path: impl AsRef<Path>) -> Result<BuildTarget, Error> {
         Ok(BuildTarget {
             name: target.name.clone(),
-            src_path: target.src_path.strip_prefix(&package_path)?.to_path_buf(),
+            src_path: target.src_path.canonicalize()?.strip_prefix(&package_path)?.to_path_buf(),
         })
     }
 }


### PR DESCRIPTION
When the ~/.cargo directory is symlinked, the `target.src_path` needs
to be canonicalized to be able to strip the prefix (`package_path`),
since it has already been canonicalized.

Suppose `/home/user/.cargo` is a symlink to `/mnt/.cargo`:
- if `target.src_path` is something such as      `/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/winreg-0.6.2`
- then `package_path` would be something such as `/mnt/.cargo/registry/src/github.com-1ecc6299db9ec823/winreg-0.6.2`

In this scenario, since `package_path` is not a prefix of
`target.src_path`, `strip_prefix` returns an error and no `libPath`
attribute are created.

Fixes #36