### PR TITLE
Add (basic) support for running tests

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -3537,15 +3537,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -20,7 +20,7 @@ rec {
   #
 
   rootCrate = rec {
-    packageId = "crate2nix 0.7.0-alpha.4 (path+file:///home/peter/projects/crate2nix/crate2nix)";
+    packageId = "crate2nix 0.7.0-alpha.4 (path+file:///home/andi/dev/tweag/sc/crate2nix/crate2nix)";
 
     # Use this attribute to refer to the derivation building your root crate package.
     # You can override the features with rootCrate.build.override { features = [ "default" "feature1" ... ]; }.
@@ -40,12 +40,12 @@ rec {
   # workspaceMembers."${crateName}".build.override { features = [ "default" "feature1" ... ]; }.
   workspaceMembers = {
     "crate2nix" = rec {
-      packageId = "crate2nix 0.7.0-alpha.4 (path+file:///home/peter/projects/crate2nix/crate2nix)";
+      packageId = "crate2nix 0.7.0-alpha.4 (path+file:///home/andi/dev/tweag/sc/crate2nix/crate2nix)";
       build = buildRustCrateWithFeatures {
-        packageId = "crate2nix 0.7.0-alpha.4 (path+file:///home/peter/projects/crate2nix/crate2nix)";
+        packageId = "crate2nix 0.7.0-alpha.4 (path+file:///home/andi/dev/tweag/sc/crate2nix/crate2nix)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
@@ -68,6 +68,8 @@ rec {
   # * `dependencies`/`buildDependencies`: similar to the corresponding fields for buildRustCrate.
   #   but with additional information which is used during dependency/feature resolution.
   # * `resolvedDependencies`: the selected default features reported by cargo - only included for debugging.
+  # * `devDependencies` as of now not used by `buildRustCrate` but used to
+  #   inject test dependencies into the build
 
   crates = {
     "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)"
@@ -108,7 +110,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "windows");
+            target = {target, features}: (target."os" == "windows");
             features = [ "errhandlingapi" "consoleapi" "processenv" ];
           }
         ];
@@ -129,12 +131,12 @@ rec {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "consoleapi" "processenv" "minwinbase" "minwindef" "winbase" ];
           }
         ];
@@ -497,7 +499,7 @@ rec {
             name = "ansi_term";
             packageId = "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)";
             optional = true;
-            target = features: (!target."windows");
+            target = {target, features}: (!target."windows");
           }
           {
             name = "atty";
@@ -568,7 +570,34 @@ rec {
         features = {
         };
       };
-    "crate2nix 0.7.0-alpha.4 (path+file:///home/peter/projects/crate2nix/crate2nix)"
+    "colored-diff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "colored-diff";
+        version = "0.2.2";
+        edition = "2015";
+        sha256 = "1zbfjkp7w1wjcxb1p19dd21mn9xkj6nr2s5pav8b16whzh52cvsi";
+        authors = [
+          "Christopher Durham <cad97@cad97.com>"
+        ];
+        dependencies = [
+          {
+            name = "ansi_term";
+            packageId = "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "difference";
+            packageId = "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "itertools";
+            packageId = "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)";
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+        };
+      };
+    "crate2nix 0.7.0-alpha.4 (path+file:///home/andi/dev/tweag/sc/crate2nix/crate2nix)"
       = rec {
         crateName = "crate2nix";
         version = "0.7.0-alpha.4";
@@ -645,6 +674,20 @@ rec {
           {
             name = "url_serde";
             packageId = "url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
+        devDependencies = [
+          {
+            name = "colored-diff";
+            packageId = "colored-diff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "fs_extra";
+            packageId = "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "tempdir";
+            packageId = "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)";
           }
         ];
         features = {
@@ -826,6 +869,22 @@ rec {
         ];
         features = {
         };
+      };
+    "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "difference";
+        version = "2.0.0";
+        edition = "2015";
+        # Hack to suppress building binaries
+        crateBin = [{name = ","; path = ",";}];
+        sha256 = "1621wx4k8h452p6xzmzzvm7mz87kxh4yqz0kzxfjj9xmjxlbyk2j";
+        authors = [
+          "Johann Hofmann <mail@johann-hofmann.com>"
+        ];
+        features = {
+          "bin" = [ "getopts" ];
+        };
+        resolvedDefaultFeatures = [ "default" ];
       };
     "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
@@ -1031,6 +1090,30 @@ rec {
         features = {
         };
       };
+    "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "fs_extra";
+        version = "1.1.0";
+        edition = "2015";
+        sha256 = "0x6675wdhsx277k1k1235jwcv38naf20d8kwrk948ds26hh4lajz";
+        authors = [
+          "Denis Kurilenko <webdesus@gmail.com>"
+        ];
+        features = {
+        };
+      };
+    "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "fuchsia-cprng";
+        version = "0.1.1";
+        edition = "2018";
+        sha256 = "1fnkqrbz7ixxzsb04bsz9p0zzazanma8znfdqjvh39n14vapfvx0";
+        authors = [
+          "Erick Tryzelaar <etryzelaar@google.com>"
+        ];
+        features = {
+        };
+      };
     "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "generic-array";
@@ -1069,12 +1152,12 @@ rec {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "wasi";
             packageId = "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "wasi");
+            target = {target, features}: (target."os" == "wasi");
           }
         ];
         features = {
@@ -1321,11 +1404,31 @@ rec {
           {
             name = "winapi-util";
             packageId = "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
         ];
         features = {
           "simd-accel" = [ "globset/simd-accel" ];
+        };
+      };
+    "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "itertools";
+        version = "0.7.11";
+        edition = "2015";
+        sha256 = "03cpsj26xmyamcalclqzr1i700vwx8hnbgxbpjvs354f8mnr8iqd";
+        authors = [
+          "bluss"
+        ];
+        dependencies = [
+          {
+            name = "either";
+            packageId = "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)";
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+          "default" = [ "use_std" ];
         };
       };
     "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)"
@@ -1542,7 +1645,7 @@ rec {
           {
             name = "hermit-abi";
             packageId = "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (((target."arch" == "x86_64") || (target."arch" == "aarch64")) && (target."os" == "hermit"));
+            target = {target, features}: (((target."arch" == "x86_64") || (target."arch" == "aarch64")) && (target."os" == "hermit"));
           }
           {
             name = "libc";
@@ -1898,6 +2001,52 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "proc-macro" ];
       };
+    "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "rand";
+        version = "0.4.6";
+        edition = "2015";
+        sha256 = "14qjfv3gggzhnma20k0sc1jf8y6pplsaq7n1j9ls5c8kf2wl0a2m";
+        authors = [
+          "The Rust Project Developers"
+        ];
+        dependencies = [
+          {
+            name = "fuchsia-cprng";
+            packageId = "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)";
+            target = {target, features}: (target."os" == "fuchsia");
+          }
+          {
+            name = "libc";
+            packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
+            optional = true;
+            target = {target, features}: target."unix";
+          }
+          {
+            name = "rand_core";
+            packageId = "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)";
+            usesDefaultFeatures = false;
+            target = {target, features}: (target."env" == "sgx");
+          }
+          {
+            name = "rdrand";
+            packageId = "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
+            target = {target, features}: (target."env" == "sgx");
+          }
+          {
+            name = "winapi";
+            packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
+            target = {target, features}: target."windows";
+            features = [ "minwindef" "ntsecapi" "profileapi" "winnt" ];
+          }
+        ];
+        features = {
+          "default" = [ "std" ];
+          "nightly" = [ "i128_support" ];
+          "std" = [ "libc" ];
+        };
+        resolvedDefaultFeatures = [ "default" "libc" "std" ];
+      };
     "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "rand";
@@ -1919,13 +2068,13 @@ rec {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "rand_chacha";
             packageId = "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: (!(target."os" == "emscripten"));
+            target = {target, features}: (!(target."os" == "emscripten"));
           }
           {
             name = "rand_core";
@@ -1934,7 +2083,13 @@ rec {
           {
             name = "rand_hc";
             packageId = "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "emscripten");
+            target = {target, features}: (target."os" == "emscripten");
+          }
+        ];
+        devDependencies = [
+          {
+            name = "rand_hc";
+            packageId = "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)";
           }
         ];
         features = {
@@ -1978,6 +2133,44 @@ rec {
           "std" = [ "c2-chacha/std" ];
         };
         resolvedDefaultFeatures = [ "std" ];
+      };
+    "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "rand_core";
+        version = "0.3.1";
+        edition = "2015";
+        sha256 = "0jzdgszfa4bliigiy4hi66k7fs3gfwi2qxn8vik84ph77fwdwvvs";
+        authors = [
+          "The Rand Project Developers"
+          "The Rust Project Developers"
+        ];
+        dependencies = [
+          {
+            name = "rand_core";
+            packageId = "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
+        features = {
+          "alloc" = [ "rand_core/alloc" ];
+          "default" = [ "std" ];
+          "serde1" = [ "rand_core/serde1" ];
+          "std" = [ "rand_core/std" ];
+        };
+      };
+    "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "rand_core";
+        version = "0.4.2";
+        edition = "2015";
+        sha256 = "1p09ynysrq1vcdlmcqnapq4qakl2yd1ng3kxh3qscpx09k2a6cww";
+        authors = [
+          "The Rand Project Developers"
+          "The Rust Project Developers"
+        ];
+        features = {
+          "serde1" = [ "serde" "serde_derive" ];
+          "std" = [ "alloc" ];
+        };
       };
     "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
@@ -2083,6 +2276,27 @@ rec {
         features = {
         };
       };
+    "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "rdrand";
+        version = "0.4.0";
+        edition = "2015";
+        sha256 = "1cjq0kwx1bk7jx3kzyciiish5gqsj7620dm43dc52sr8fzmm9037";
+        authors = [
+          "Simonas Kazlauskas <rdrand@kazlauskas.me>"
+        ];
+        dependencies = [
+          {
+            name = "rand_core";
+            packageId = "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)";
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+          "default" = [ "std" ];
+        };
+        resolvedDefaultFeatures = [ "default" "std" ];
+      };
     "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "redox_syscall";
@@ -2173,7 +2387,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "std" "errhandlingapi" "winerror" "fileapi" "winbase" ];
           }
         ];
@@ -2236,7 +2450,7 @@ rec {
           {
             name = "winapi-util";
             packageId = "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
         ];
         features = {
@@ -2308,6 +2522,12 @@ rec {
             name = "serde_derive";
             packageId = "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)";
             optional = true;
+          }
+        ];
+        devDependencies = [
+          {
+            name = "serde_derive";
+            packageId = "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)";
           }
         ];
         features = {
@@ -2401,6 +2621,13 @@ rec {
           {
             name = "opaque-debug";
             packageId = "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
+        devDependencies = [
+          {
+            name = "digest";
+            packageId = "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)";
+            features = [ "dev" ];
           }
         ];
         features = {
@@ -2623,6 +2850,28 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "proc-macro" ];
       };
+    "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)"
+      = rec {
+        crateName = "tempdir";
+        version = "0.3.7";
+        edition = "2015";
+        sha256 = "1n5n86zxpgd85y0mswrp5cfdisizq2rv3la906g6ipyc03xvbwhm";
+        authors = [
+          "The Rust Project Developers"
+        ];
+        dependencies = [
+          {
+            name = "rand";
+            packageId = "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "remove_dir_all";
+            packageId = "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
+        features = {
+        };
+      };
     "tera 1.0.0-beta.20 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "tera";
@@ -2717,7 +2966,7 @@ rec {
           {
             name = "wincolor";
             packageId = "wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
         ];
         features = {
@@ -2776,13 +3025,20 @@ rec {
           {
             name = "redox_syscall";
             packageId = "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "redox");
+            target = {target, features}: (target."os" == "redox");
           }
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "std" "minwinbase" "minwindef" "ntdef" "profileapi" "sysinfoapi" "timezoneapi" ];
+          }
+        ];
+        devDependencies = [
+          {
+            name = "winapi";
+            packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
+            features = [ "std" "processthreadsapi" "winbase" ];
           }
         ];
         features = {
@@ -3155,13 +3411,13 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "std" "winnt" ];
           }
           {
             name = "winapi-util";
             packageId = "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
         ];
         features = {
@@ -3195,12 +3451,12 @@ rec {
           {
             name = "winapi-i686-pc-windows-gnu";
             packageId = "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (stdenv.hostPlatform.config == "i686-pc-windows-gnu");
+            target = {target, features}: (stdenv.hostPlatform.config == "i686-pc-windows-gnu");
           }
           {
             name = "winapi-x86_64-pc-windows-gnu";
             packageId = "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (stdenv.hostPlatform.config == "x86_64-pc-windows-gnu");
+            target = {target, features}: (stdenv.hostPlatform.config == "x86_64-pc-windows-gnu");
           }
         ];
         features = {
@@ -3233,7 +3489,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "std" "consoleapi" "errhandlingapi" "fileapi" "minwindef" "processenv" "winbase" "wincon" "winerror" "winnt" ];
           }
         ];
@@ -3283,11 +3539,10 @@ rec {
 
   # Target (platform) data for conditional dependencies.
   # This corresponds roughly to what buildRustCrate is setting.
-  target = {
+  defaultTarget = {
       unix = true;
       windows = false;
       fuchsia = true;
-      # We don't support tests yet, so this is true for now.
       test = false;
 
       # This doesn't appear to be officially documented anywhere yet.
@@ -3345,66 +3600,138 @@ rec {
       baseName == "tests.nix"
     );
 
+  /* Returns a crate which depends on successful test execution of crate given as the second argument */
+  crateWithTest = crate: testCrate: testCrateFlags:
+    let
+      # override the `crate` so that it will build and execute tests instead of
+      # building the actual lib and bin targets We just have to pass `--test`
+      # to rustc and it will do the right thing.  We execute the tests and copy
+      # their log and the test executables to $out for later inspection.
+      test = let
+        drv = testCrate.override (_: {
+          buildTests = true;
+        });
+      in pkgs.runCommand "run-tests-${testCrate.name}" {
+        inherit testCrateFlags;
+      } ''
+        set -e
+        for file in ${drv}/tests/*; do
+          echo "Executing test $file" | tee -a $out
+          $file -- "$testCrateFlags" 2>&1 | tee -a $out
+        done
+      '';
+    in crate.overrideAttrs (old: {
+      checkPhase = ''
+        test -e ${test}
+      '';
+      passthru = (old.passthru or {}) // {
+        inherit test;
+      };
+    });
+
   /* A restricted overridable version of  buildRustCrateWithFeaturesImpl. */
-  buildRustCrateWithFeatures = {
-        packageId, 
-        features ? rootFeatures,
-        crateOverrides ? defaultCrateOverrides, 
-        buildRustCrateFunc ? buildRustCrate
-      }:
+  buildRustCrateWithFeatures =
+    { packageId
+    , features ? rootFeatures
+    , crateOverrides ? defaultCrateOverrides
+    , buildRustCrateFunc ? buildRustCrate
+    , runTests ? false
+    , testCrateFlags ? []
+    }:
     lib.makeOverridable
-      ({features, crateOverrides}: 
-        let builtRustCrates = builtRustCratesWithFeatures {
-          inherit packageId features crateOverrides  buildRustCrateFunc;
-        };
-        in builtRustCrates.${packageId})
-      { inherit features crateOverrides; };
+      ({features, crateOverrides, runTests, testCrateFlags}:
+        let
+          builtRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = false;
+          };
+          builtTestRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = true;
+          };
+          drv = builtRustCrates.${packageId};
+          testDrv = builtTestRustCrates.${packageId};
+        in if runTests then crateWithTest drv testDrv testCrateFlags else drv)
+      { inherit features crateOverrides runTests testCrateFlags; };
 
   /* Returns a buildRustCrate derivation for the given packageId and features. */
-  builtRustCratesWithFeatures = { 
-        crateConfigs? crates, 
-        packageId,
-        features,
-        crateOverrides, 
-        buildRustCrateFunc
-      } @ args:
+  builtRustCratesWithFeatures =
+    { packageId
+    , features
+    , crateConfigs ? crates
+    , crateOverrides
+    , buildRustCrateFunc
+    , runTests
+    , target ? defaultTarget
+    } @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
+    assert (builtins.isBool runTests);
 
-    let mergedFeatures = mergePackageFeatures args;
+    let rootPackageId = packageId;
+        mergedFeatures = mergePackageFeatures (args // {
+          inherit rootPackageId;
+          target = target // { test = runTests; };
+        });
+
+        buildByPackageId = packageId: buildByPackageIdImpl packageId;
+
         # Memoize built packages so that reappearing packages are only built once.
         builtByPackageId =
           lib.mapAttrs (packageId: value: buildByPackageId packageId) crateConfigs;
-        buildByPackageId = packageId:
-          let features = mergedFeatures."${packageId}" or [];
-              crateConfig = lib.filterAttrs (n: v: n != "resolvedDefaultFeatures") crateConfigs."${packageId}";
+
+        buildByPackageIdImpl = packageId:
+          let
+              features = mergedFeatures."${packageId}" or [];
+              crateConfig' = crateConfigs."${packageId}";
+              crateConfig = builtins.removeAttrs crateConfig' ["resolvedDefaultFeatures" "devDependencies"];
+              devDependencies = lib.optionals (runTests && packageId == rootPackageId) (crateConfig'.devDependencies or []);
               dependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.dependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies =
+                   (crateConfig.dependencies or [])
+                    ++ devDependencies;
+                };
               buildDependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.buildDependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies = crateConfig.buildDependencies or [];
+                };
+
               dependenciesWithRenames =
-                lib.filter (d: d ? "rename")
-                  (crateConfig.buildDependencies or [] ++ crateConfig.dependencies or []);
+                lib.filter (d: d ? "rename") (
+                  (crateConfig.buildDependencies or [])
+                  ++ (crateConfig.dependencies or [])
+                  ++ devDependencies);
+
               crateRenames =
                 builtins.listToAttrs (map (d: { name = d.name; value = d.rename; }) dependenciesWithRenames);
-          in buildRustCrateFunc (crateConfig // { 
+          in buildRustCrateFunc (crateConfig // {
             src = crateConfig.src or (pkgs.fetchurl {
               name = "${crateConfig.crateName}-${crateConfig.version}.tar.gz";
               url = "https://crates.io/api/v1/crates/${crateConfig.crateName}/${crateConfig.version}/download";
               sha256 = crateConfig.sha256;
             });
-            inherit features dependencies buildDependencies crateRenames; 
+            inherit features dependencies buildDependencies crateRenames;
           });
     in builtByPackageId;
 
   /* Returns the actual derivations for the given dependencies. */
-  dependencyDerivations = builtByPackageId: features: dependencies:
+  dependencyDerivations =
+    { builtByPackageId
+    , features
+    , dependencies
+    , target
+    }:
     assert (builtins.isAttrs builtByPackageId);
     assert (builtins.isList features);
     assert (builtins.isList dependencies);
+    assert (builtins.isAttrs target);
 
-    let enabledDependencies = filterEnabledDependencies dependencies features;
+    let enabledDependencies = filterEnabledDependencies { inherit dependencies features target; };
         depDerivation = dependency: builtByPackageId.${dependency.packageId};
     in map depDerivation enabledDependencies;
 
@@ -3417,7 +3744,7 @@ rec {
           then "function"
           else val;
 
-  debugCrate = {packageId}:
+  debugCrate = {packageId, target}:
     assert (builtins.isString packageId);
 
     rec {
@@ -3435,7 +3762,7 @@ rec {
             };
             inherit packageId;
         });
-        mergedPackageFeatures = mergePackageFeatures { inherit packageId; features = rootFeatures; };
+        mergedPackageFeatures = mergePackageFeatures { inherit packageId target; features = rootFeatures; };
         diffedDefaultPackageFeatures = diffDefaultPackageFeatures { inherit packageId;  features = rootFeatures; };
     };
 
@@ -3443,14 +3770,18 @@ rec {
    *
    * This is useful for verifying the feature resolution in crate2nix.
    */
-  diffDefaultPackageFeatures = {crateConfigs ? crates, packageId}:
+  diffDefaultPackageFeatures =
+    { crateConfigs ? crates
+    , packageId
+    , target
+    }:
     assert (builtins.isAttrs crateConfigs);
 
     let prefixValues = prefix: lib.mapAttrs (n: v: { "${prefix}" = v; });
         mergedFeatures =
           prefixValues
             "crate2nix"
-            (mergePackageFeatures {inherit crateConfigs packageId; features = ["default"]; });
+            (mergePackageFeatures {inherit crateConfigs packageId target; features = ["default"]; });
         configs = prefixValues "cargo" crateConfigs;
         combined = lib.foldAttrs (a: b: a // b) {} [ mergedFeatures configs ];
         onlyInCargo = builtins.attrNames (lib.filterAttrs (n: v: !(v ? "crate2nix" ) && (v ? "cargo")) combined);
@@ -3471,12 +3802,16 @@ rec {
      Returns multiple, potentially conflicting attribute sets for dependencies that are reachable
      by multiple paths in the dependency tree.
   */
+
   mergePackageFeatures = {
     crateConfigs ? crates,
     packageId,
+    rootPackageId,
     features ? rootFeatures,
     dependencyPath? [crates.${packageId}.crateName],
     featuresByPackageId? {},
+    target,
+    runTests,
     ...} @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
@@ -3496,7 +3831,10 @@ rec {
           assert (builtins.isAttrs cache);
           assert (builtins.isList dependencies);
 
-          let enabledDependencies = filterEnabledDependencies dependencies expandedFeatures;
+          let enabledDependencies = filterEnabledDependencies {
+                inherit dependencies target;
+                features = expandedFeatures;
+              };
               directDependencies = map depWithResolvedFeatures enabledDependencies;
               foldOverCache = op: lib.foldl op cache directDependencies;
           in foldOverCache
@@ -3511,7 +3849,7 @@ rec {
                   dependencyPath = dependencyPath ++ [path crateConfigs.${packageId}.crateName];
                   features = combinedFeatures;
                   featuresByPackageId = cache;
-                  inherit crateConfigs packageId;
+                  inherit crateConfigs packageId target runTests rootPackageId;
                  });
 
         cacheWithSelf =
@@ -3522,21 +3860,25 @@ rec {
             };
 
         cacheWithDependencies =
-            resolveDependencies cacheWithSelf "dep" (crateConfig.dependencies or []);
+            resolveDependencies cacheWithSelf "dep" (
+              crateConfig.dependencies or []
+              ++ lib.optionals (runTests && packageId == rootPackageId) (crateConfig.devDependencies or [])
+        );
         cacheWithAll =
             resolveDependencies cacheWithDependencies "build" (crateConfig.buildDependencies or []);
 
     in cacheWithAll;
 
   /* Returns the enabled dependencies given the enabled features. */
-  filterEnabledDependencies = dependencies: features:
+  filterEnabledDependencies = {dependencies, features, target}:
     assert (builtins.isList dependencies);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
 
     lib.filter
       (dep:
         let targetFunc = dep.target or (features: true);
-        in targetFunc features
+        in targetFunc { inherit features target; }
            && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 

--- a/crate2nix/src/lib.rs
+++ b/crate2nix/src/lib.rs
@@ -83,7 +83,10 @@ impl BuildInfo {
                 indexed_crates
                     .get(next_package_id)
                     .iter()
-                    .flat_map(|c| c.dependencies.iter().chain(c.build_dependencies.iter()))
+                    .flat_map(|c| c.dependencies.iter()
+                              .chain(c.build_dependencies.iter())
+                              .chain(c.dev_dependencies.iter())
+                    )
                     .map(|d| &d.package_id),
             );
         }

--- a/crate2nix/src/resolve.rs
+++ b/crate2nix/src/resolve.rs
@@ -32,6 +32,7 @@ pub struct CrateDerivation {
     pub source: ResolvedSource,
     pub dependencies: Vec<ResolvedDependency>,
     pub build_dependencies: Vec<ResolvedDependency>,
+    pub dev_dependencies: Vec<ResolvedDependency>,
     /// Feature rules. Which feature (key) enables which other features (values).
     pub features: BTreeMap<String, Vec<String>>,
     /// The resolved features for this crate for a default build as returned by cargo.
@@ -59,6 +60,9 @@ impl CrateDerivation {
         let dependencies = resolved_dependencies.filtered_dependencies(|d| {
             d.kind == DependencyKind::Normal || d.kind == DependencyKind::Unknown
         });
+
+        let dev_dependencies =
+            resolved_dependencies.filtered_dependencies(|d| d.kind == DependencyKind::Development);
 
         let package_path = package
             .manifest_path
@@ -121,6 +125,7 @@ impl CrateDerivation {
                 .unwrap_or_else(|| Vec::new()),
             dependencies,
             build_dependencies,
+            dev_dependencies,
             build,
             lib,
             proc_macro,

--- a/crate2nix/templates/build.nix.tera
+++ b/crate2nix/templates/build.nix.tera
@@ -155,7 +155,7 @@ rec {
             usesDefaultFeatures = false;
             {%- endif -%}
             {%- if dependency.target %}
-            target = features: {{dependency.target | cfg_to_nix_expr | safe }};
+            target = {target, features}: {{dependency.target | cfg_to_nix_expr | safe }};
             {%- endif %}
             {%- if dependency.features %}
             features = [ {% for feature in dependency.features %}{{feature}} {% endfor %}];
@@ -178,7 +178,7 @@ rec {
             usesDefaultFeatures = false;
             {%- endif -%}
             {%- if dependency.target %}
-            target = features: {{dependency.target | cfg_to_nix_expr | safe }};
+            target = {target, features}: {{dependency.target | cfg_to_nix_expr | safe }};
             {%- endif %}
             {%- if dependency.features %}
             features = [ {% for feature in dependency.features %}{{feature}} {% endfor %}];

--- a/crate2nix/templates/build.nix.tera
+++ b/crate2nix/templates/build.nix.tera
@@ -51,7 +51,7 @@ rec {
         packageId = {{pkg_id}};
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };

--- a/crate2nix/templates/build.nix.tera
+++ b/crate2nix/templates/build.nix.tera
@@ -76,6 +76,8 @@ rec {
   # * `dependencies`/`buildDependencies`: similar to the corresponding fields for buildRustCrate.
   #   but with additional information which is used during dependency/feature resolution.
   # * `resolvedDependencies`: the selected default features reported by cargo - only included for debugging.
+  # * `devDependencies` as of now not used by `buildRustCrate` but used to
+  #   inject test dependencies into the build
 
   crates = {
   {%- for crate in crates %}
@@ -187,6 +189,29 @@ rec {
         {%- endfor %}
         ];
         {%- endif -%}
+        {%- if crate.dev_dependencies|length > 0 %}
+        devDependencies = [
+        {%- for dependency in crate.dev_dependencies %}
+          {
+            name = {{dependency.name}};
+            packageId = {{dependency.package_id}};
+            {%- if dependency.optional %}
+            optional = true;
+            {%- endif -%}
+            {%- if not dependency.uses_default_features %}
+            usesDefaultFeatures = false;
+            {%- endif -%}
+            {%- if dependency.target %}
+            target = {target, features}: {{dependency.target | cfg_to_nix_expr | safe }};
+            {%- endif %}
+            {%- if dependency.features %}
+            features = [ {% for feature in dependency.features %}{{feature}} {% endfor %}];
+            {%- endif %}
+          }
+        {%- endfor %}
+        ];
+        {%- endif -%}
+
         {#- #}
         features = {
         {%- for feature, features in crate.features -%}

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -261,15 +261,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -156,11 +156,14 @@ rec {
         buildByPackageIdImpl = packageId:
           let
               features = mergedFeatures."${packageId}" or [];
-              crateConfig = lib.filterAttrs (n: v: n != "resolvedDefaultFeatures") crateConfigs."${packageId}";
+              crateConfig' = crateConfigs."${packageId}";
+              crateConfig = builtins.removeAttrs crateConfig' ["resolvedDefaultFeatures" "devDependencies"];
               dependencies =
                 dependencyDerivations {
                   inherit builtByPackageId features target;
-                  dependencies = crateConfig.dependencies or [];
+                  dependencies =
+                       (crateConfig.dependencies or [])
+                    ++ lib.optionals doTest (crateConfig'.devDependencies or []);
                 };
               buildDependencies =
                 dependencyDerivations {

--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,6 @@
 
 let cargo_nix = callPackage ./crate2nix/Cargo.nix {};
     crate2nix = cargo_nix.rootCrate.build.override {
-      runTests = true;
       testCrateFlags = [
         "--skip nix_integration_tests"
         "--skip nix_unit_tests"
@@ -20,7 +19,6 @@ let cargo_nix = callPackage ./crate2nix/Cargo.nix {};
           buildInputs = stdenv.lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security]; };
       };
     };
-
 in pkgs.symlinkJoin {
   name = crate2nix.name;
   paths = [ crate2nix ];

--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,11 @@
 
 let cargo_nix = callPackage ./crate2nix/Cargo.nix {};
     crate2nix = cargo_nix.rootCrate.build.override {
-      doTest = true;
+      runTests = true;
+      testCrateFlags = [
+        "--skip nix_integration_tests"
+        "--skip nix_unit_tests"
+      ];
       crateOverrides = defaultCrateOverrides // {
         cssparser-macros = attrs: {
           buildInputs = stdenv.lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security]; };

--- a/default.nix
+++ b/default.nix
@@ -10,8 +10,9 @@
 
 let cargo_nix = callPackage ./crate2nix/Cargo.nix {};
     crate2nix = cargo_nix.rootCrate.build.override {
+      doTest = true;
       crateOverrides = defaultCrateOverrides // {
-        cssparser-macros = attrs: { 
+        cssparser-macros = attrs: {
           buildInputs = stdenv.lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security]; };
       };
     };

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -369,15 +369,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -20,7 +20,7 @@ rec {
   #
 
   rootCrate = rec {
-    packageId = "bin_with_lib_git_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_git_branch_dep)";
+    packageId = "bin_with_lib_git_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_git_branch_dep)";
 
     # Use this attribute to refer to the derivation building your root crate package.
     # You can override the features with rootCrate.build.override { features = [ "default" "feature1" ... ]; }.
@@ -40,12 +40,12 @@ rec {
   # workspaceMembers."${crateName}".build.override { features = [ "default" "feature1" ... ]; }.
   workspaceMembers = {
     "bin_with_lib_git_dep" = rec {
-      packageId = "bin_with_lib_git_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_git_branch_dep)";
+      packageId = "bin_with_lib_git_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_git_branch_dep)";
       build = buildRustCrateWithFeatures {
-        packageId = "bin_with_lib_git_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_git_branch_dep)";
+        packageId = "bin_with_lib_git_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_git_branch_dep)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
@@ -68,9 +68,11 @@ rec {
   # * `dependencies`/`buildDependencies`: similar to the corresponding fields for buildRustCrate.
   #   but with additional information which is used during dependency/feature resolution.
   # * `resolvedDependencies`: the selected default features reported by cargo - only included for debugging.
+  # * `devDependencies` as of now not used by `buildRustCrate` but used to
+  #   inject test dependencies into the build
 
   crates = {
-    "bin_with_lib_git_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_git_branch_dep)"
+    "bin_with_lib_git_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_git_branch_dep)"
       = rec {
         crateName = "bin_with_lib_git_dep";
         version = "0.1.0";
@@ -115,11 +117,10 @@ rec {
 
   # Target (platform) data for conditional dependencies.
   # This corresponds roughly to what buildRustCrate is setting.
-  target = {
+  defaultTarget = {
       unix = true;
       windows = false;
       fuchsia = true;
-      # We don't support tests yet, so this is true for now.
       test = false;
 
       # This doesn't appear to be officially documented anywhere yet.
@@ -177,66 +178,138 @@ rec {
       baseName == "tests.nix"
     );
 
+  /* Returns a crate which depends on successful test execution of crate given as the second argument */
+  crateWithTest = crate: testCrate: testCrateFlags:
+    let
+      # override the `crate` so that it will build and execute tests instead of
+      # building the actual lib and bin targets We just have to pass `--test`
+      # to rustc and it will do the right thing.  We execute the tests and copy
+      # their log and the test executables to $out for later inspection.
+      test = let
+        drv = testCrate.override (_: {
+          buildTests = true;
+        });
+      in pkgs.runCommand "run-tests-${testCrate.name}" {
+        inherit testCrateFlags;
+      } ''
+        set -e
+        for file in ${drv}/tests/*; do
+          echo "Executing test $file" | tee -a $out
+          $file -- "$testCrateFlags" 2>&1 | tee -a $out
+        done
+      '';
+    in crate.overrideAttrs (old: {
+      checkPhase = ''
+        test -e ${test}
+      '';
+      passthru = (old.passthru or {}) // {
+        inherit test;
+      };
+    });
+
   /* A restricted overridable version of  buildRustCrateWithFeaturesImpl. */
-  buildRustCrateWithFeatures = {
-        packageId, 
-        features ? rootFeatures,
-        crateOverrides ? defaultCrateOverrides, 
-        buildRustCrateFunc ? buildRustCrate
-      }:
+  buildRustCrateWithFeatures =
+    { packageId
+    , features ? rootFeatures
+    , crateOverrides ? defaultCrateOverrides
+    , buildRustCrateFunc ? buildRustCrate
+    , runTests ? false
+    , testCrateFlags ? []
+    }:
     lib.makeOverridable
-      ({features, crateOverrides}: 
-        let builtRustCrates = builtRustCratesWithFeatures {
-          inherit packageId features crateOverrides  buildRustCrateFunc;
-        };
-        in builtRustCrates.${packageId})
-      { inherit features crateOverrides; };
+      ({features, crateOverrides, runTests, testCrateFlags}:
+        let
+          builtRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = false;
+          };
+          builtTestRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = true;
+          };
+          drv = builtRustCrates.${packageId};
+          testDrv = builtTestRustCrates.${packageId};
+        in if runTests then crateWithTest drv testDrv testCrateFlags else drv)
+      { inherit features crateOverrides runTests testCrateFlags; };
 
   /* Returns a buildRustCrate derivation for the given packageId and features. */
-  builtRustCratesWithFeatures = { 
-        crateConfigs? crates, 
-        packageId,
-        features,
-        crateOverrides, 
-        buildRustCrateFunc
-      } @ args:
+  builtRustCratesWithFeatures =
+    { packageId
+    , features
+    , crateConfigs ? crates
+    , crateOverrides
+    , buildRustCrateFunc
+    , runTests
+    , target ? defaultTarget
+    } @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
+    assert (builtins.isBool runTests);
 
-    let mergedFeatures = mergePackageFeatures args;
+    let rootPackageId = packageId;
+        mergedFeatures = mergePackageFeatures (args // {
+          inherit rootPackageId;
+          target = target // { test = runTests; };
+        });
+
+        buildByPackageId = packageId: buildByPackageIdImpl packageId;
+
         # Memoize built packages so that reappearing packages are only built once.
         builtByPackageId =
           lib.mapAttrs (packageId: value: buildByPackageId packageId) crateConfigs;
-        buildByPackageId = packageId:
-          let features = mergedFeatures."${packageId}" or [];
-              crateConfig = lib.filterAttrs (n: v: n != "resolvedDefaultFeatures") crateConfigs."${packageId}";
+
+        buildByPackageIdImpl = packageId:
+          let
+              features = mergedFeatures."${packageId}" or [];
+              crateConfig' = crateConfigs."${packageId}";
+              crateConfig = builtins.removeAttrs crateConfig' ["resolvedDefaultFeatures" "devDependencies"];
+              devDependencies = lib.optionals (runTests && packageId == rootPackageId) (crateConfig'.devDependencies or []);
               dependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.dependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies =
+                   (crateConfig.dependencies or [])
+                    ++ devDependencies;
+                };
               buildDependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.buildDependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies = crateConfig.buildDependencies or [];
+                };
+
               dependenciesWithRenames =
-                lib.filter (d: d ? "rename")
-                  (crateConfig.buildDependencies or [] ++ crateConfig.dependencies or []);
+                lib.filter (d: d ? "rename") (
+                  (crateConfig.buildDependencies or [])
+                  ++ (crateConfig.dependencies or [])
+                  ++ devDependencies);
+
               crateRenames =
                 builtins.listToAttrs (map (d: { name = d.name; value = d.rename; }) dependenciesWithRenames);
-          in buildRustCrateFunc (crateConfig // { 
+          in buildRustCrateFunc (crateConfig // {
             src = crateConfig.src or (pkgs.fetchurl {
               name = "${crateConfig.crateName}-${crateConfig.version}.tar.gz";
               url = "https://crates.io/api/v1/crates/${crateConfig.crateName}/${crateConfig.version}/download";
               sha256 = crateConfig.sha256;
             });
-            inherit features dependencies buildDependencies crateRenames; 
+            inherit features dependencies buildDependencies crateRenames;
           });
     in builtByPackageId;
 
   /* Returns the actual derivations for the given dependencies. */
-  dependencyDerivations = builtByPackageId: features: dependencies:
+  dependencyDerivations =
+    { builtByPackageId
+    , features
+    , dependencies
+    , target
+    }:
     assert (builtins.isAttrs builtByPackageId);
     assert (builtins.isList features);
     assert (builtins.isList dependencies);
+    assert (builtins.isAttrs target);
 
-    let enabledDependencies = filterEnabledDependencies dependencies features;
+    let enabledDependencies = filterEnabledDependencies { inherit dependencies features target; };
         depDerivation = dependency: builtByPackageId.${dependency.packageId};
     in map depDerivation enabledDependencies;
 
@@ -249,7 +322,7 @@ rec {
           then "function"
           else val;
 
-  debugCrate = {packageId}:
+  debugCrate = {packageId, target}:
     assert (builtins.isString packageId);
 
     rec {
@@ -267,7 +340,7 @@ rec {
             };
             inherit packageId;
         });
-        mergedPackageFeatures = mergePackageFeatures { inherit packageId; features = rootFeatures; };
+        mergedPackageFeatures = mergePackageFeatures { inherit packageId target; features = rootFeatures; };
         diffedDefaultPackageFeatures = diffDefaultPackageFeatures { inherit packageId;  features = rootFeatures; };
     };
 
@@ -275,14 +348,18 @@ rec {
    *
    * This is useful for verifying the feature resolution in crate2nix.
    */
-  diffDefaultPackageFeatures = {crateConfigs ? crates, packageId}:
+  diffDefaultPackageFeatures =
+    { crateConfigs ? crates
+    , packageId
+    , target
+    }:
     assert (builtins.isAttrs crateConfigs);
 
     let prefixValues = prefix: lib.mapAttrs (n: v: { "${prefix}" = v; });
         mergedFeatures =
           prefixValues
             "crate2nix"
-            (mergePackageFeatures {inherit crateConfigs packageId; features = ["default"]; });
+            (mergePackageFeatures {inherit crateConfigs packageId target; features = ["default"]; });
         configs = prefixValues "cargo" crateConfigs;
         combined = lib.foldAttrs (a: b: a // b) {} [ mergedFeatures configs ];
         onlyInCargo = builtins.attrNames (lib.filterAttrs (n: v: !(v ? "crate2nix" ) && (v ? "cargo")) combined);
@@ -303,12 +380,16 @@ rec {
      Returns multiple, potentially conflicting attribute sets for dependencies that are reachable
      by multiple paths in the dependency tree.
   */
+
   mergePackageFeatures = {
     crateConfigs ? crates,
     packageId,
+    rootPackageId,
     features ? rootFeatures,
     dependencyPath? [crates.${packageId}.crateName],
     featuresByPackageId? {},
+    target,
+    runTests,
     ...} @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
@@ -328,7 +409,10 @@ rec {
           assert (builtins.isAttrs cache);
           assert (builtins.isList dependencies);
 
-          let enabledDependencies = filterEnabledDependencies dependencies expandedFeatures;
+          let enabledDependencies = filterEnabledDependencies {
+                inherit dependencies target;
+                features = expandedFeatures;
+              };
               directDependencies = map depWithResolvedFeatures enabledDependencies;
               foldOverCache = op: lib.foldl op cache directDependencies;
           in foldOverCache
@@ -343,7 +427,7 @@ rec {
                   dependencyPath = dependencyPath ++ [path crateConfigs.${packageId}.crateName];
                   features = combinedFeatures;
                   featuresByPackageId = cache;
-                  inherit crateConfigs packageId;
+                  inherit crateConfigs packageId target runTests rootPackageId;
                  });
 
         cacheWithSelf =
@@ -354,21 +438,25 @@ rec {
             };
 
         cacheWithDependencies =
-            resolveDependencies cacheWithSelf "dep" (crateConfig.dependencies or []);
+            resolveDependencies cacheWithSelf "dep" (
+              crateConfig.dependencies or []
+              ++ lib.optionals (runTests && packageId == rootPackageId) (crateConfig.devDependencies or [])
+        );
         cacheWithAll =
             resolveDependencies cacheWithDependencies "build" (crateConfig.buildDependencies or []);
 
     in cacheWithAll;
 
   /* Returns the enabled dependencies given the enabled features. */
-  filterEnabledDependencies = dependencies: features:
+  filterEnabledDependencies = {dependencies, features, target}:
     assert (builtins.isList dependencies);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
 
     lib.filter
       (dep:
         let targetFunc = dep.target or (features: true);
-        in targetFunc features
+        in targetFunc { inherit features target; }
            && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -20,7 +20,7 @@ rec {
   #
 
   rootCrate = rec {
-    packageId = "bin_with_git_submodule_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_git_submodule_dep)";
+    packageId = "bin_with_git_submodule_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_git_submodule_dep)";
 
     # Use this attribute to refer to the derivation building your root crate package.
     # You can override the features with rootCrate.build.override { features = [ "default" "feature1" ... ]; }.
@@ -40,12 +40,12 @@ rec {
   # workspaceMembers."${crateName}".build.override { features = [ "default" "feature1" ... ]; }.
   workspaceMembers = {
     "bin_with_git_submodule_dep" = rec {
-      packageId = "bin_with_git_submodule_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_git_submodule_dep)";
+      packageId = "bin_with_git_submodule_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_git_submodule_dep)";
       build = buildRustCrateWithFeatures {
-        packageId = "bin_with_git_submodule_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_git_submodule_dep)";
+        packageId = "bin_with_git_submodule_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_git_submodule_dep)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
@@ -68,6 +68,8 @@ rec {
   # * `dependencies`/`buildDependencies`: similar to the corresponding fields for buildRustCrate.
   #   but with additional information which is used during dependency/feature resolution.
   # * `resolvedDependencies`: the selected default features reported by cargo - only included for debugging.
+  # * `devDependencies` as of now not used by `buildRustCrate` but used to
+  #   inject test dependencies into the build
 
   crates = {
     "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)"
@@ -108,7 +110,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "windows");
+            target = {target, features}: (target."os" == "windows");
             features = [ "errhandlingapi" "consoleapi" "processenv" ];
           }
         ];
@@ -129,12 +131,12 @@ rec {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "consoleapi" "processenv" "minwinbase" "minwindef" "winbase" ];
           }
         ];
@@ -207,7 +209,7 @@ rec {
           "rustc-dep-of-std" = [ "core" "compiler_builtins" ];
         };
       };
-    "bin_with_git_submodule_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_git_submodule_dep)"
+    "bin_with_git_submodule_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_git_submodule_dep)"
       = rec {
         crateName = "bin_with_git_submodule_dep";
         version = "0.1.0";
@@ -308,6 +310,16 @@ rec {
           {
             name = "which";
             packageId = "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
+        devDependencies = [
+          {
+            name = "clap";
+            packageId = "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+          {
+            name = "shlex";
+            packageId = "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)";
           }
         ];
         features = {
@@ -462,7 +474,7 @@ rec {
             name = "ansi_term";
             packageId = "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)";
             optional = true;
-            target = features: (!target."windows");
+            target = {target, features}: (!target."windows");
           }
           {
             name = "atty";
@@ -604,12 +616,12 @@ rec {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "wasi";
             packageId = "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "wasi");
+            target = {target, features}: (target."os" == "wasi");
           }
         ];
         features = {
@@ -681,12 +693,12 @@ rec {
           {
             name = "getrandom";
             packageId = "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
           {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "log";
@@ -738,7 +750,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "winerror" "errhandlingapi" "libloaderapi" ];
           }
         ];
@@ -870,7 +882,7 @@ rec {
           {
             name = "hermit-abi";
             packageId = "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (((target."arch" == "x86_64") || (target."arch" == "aarch64")) && (target."os" == "hermit"));
+            target = {target, features}: (((target."arch" == "x86_64") || (target."arch" == "aarch64")) && (target."os" == "hermit"));
           }
           {
             name = "libc";
@@ -1092,7 +1104,7 @@ rec {
           {
             name = "wincolor";
             packageId = "wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
         ];
         features = {
@@ -1264,12 +1276,12 @@ rec {
           {
             name = "winapi-i686-pc-windows-gnu";
             packageId = "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (stdenv.hostPlatform.config == "i686-pc-windows-gnu");
+            target = {target, features}: (stdenv.hostPlatform.config == "i686-pc-windows-gnu");
           }
           {
             name = "winapi-x86_64-pc-windows-gnu";
             packageId = "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (stdenv.hostPlatform.config == "x86_64-pc-windows-gnu");
+            target = {target, features}: (stdenv.hostPlatform.config == "x86_64-pc-windows-gnu");
           }
         ];
         features = {
@@ -1302,7 +1314,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "std" "consoleapi" "errhandlingapi" "fileapi" "minwindef" "processenv" "winbase" "wincon" "winerror" "winnt" ];
           }
         ];
@@ -1352,11 +1364,10 @@ rec {
 
   # Target (platform) data for conditional dependencies.
   # This corresponds roughly to what buildRustCrate is setting.
-  target = {
+  defaultTarget = {
       unix = true;
       windows = false;
       fuchsia = true;
-      # We don't support tests yet, so this is true for now.
       test = false;
 
       # This doesn't appear to be officially documented anywhere yet.
@@ -1414,66 +1425,138 @@ rec {
       baseName == "tests.nix"
     );
 
+  /* Returns a crate which depends on successful test execution of crate given as the second argument */
+  crateWithTest = crate: testCrate: testCrateFlags:
+    let
+      # override the `crate` so that it will build and execute tests instead of
+      # building the actual lib and bin targets We just have to pass `--test`
+      # to rustc and it will do the right thing.  We execute the tests and copy
+      # their log and the test executables to $out for later inspection.
+      test = let
+        drv = testCrate.override (_: {
+          buildTests = true;
+        });
+      in pkgs.runCommand "run-tests-${testCrate.name}" {
+        inherit testCrateFlags;
+      } ''
+        set -e
+        for file in ${drv}/tests/*; do
+          echo "Executing test $file" | tee -a $out
+          $file -- "$testCrateFlags" 2>&1 | tee -a $out
+        done
+      '';
+    in crate.overrideAttrs (old: {
+      checkPhase = ''
+        test -e ${test}
+      '';
+      passthru = (old.passthru or {}) // {
+        inherit test;
+      };
+    });
+
   /* A restricted overridable version of  buildRustCrateWithFeaturesImpl. */
-  buildRustCrateWithFeatures = {
-        packageId, 
-        features ? rootFeatures,
-        crateOverrides ? defaultCrateOverrides, 
-        buildRustCrateFunc ? buildRustCrate
-      }:
+  buildRustCrateWithFeatures =
+    { packageId
+    , features ? rootFeatures
+    , crateOverrides ? defaultCrateOverrides
+    , buildRustCrateFunc ? buildRustCrate
+    , runTests ? false
+    , testCrateFlags ? []
+    }:
     lib.makeOverridable
-      ({features, crateOverrides}: 
-        let builtRustCrates = builtRustCratesWithFeatures {
-          inherit packageId features crateOverrides  buildRustCrateFunc;
-        };
-        in builtRustCrates.${packageId})
-      { inherit features crateOverrides; };
+      ({features, crateOverrides, runTests, testCrateFlags}:
+        let
+          builtRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = false;
+          };
+          builtTestRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = true;
+          };
+          drv = builtRustCrates.${packageId};
+          testDrv = builtTestRustCrates.${packageId};
+        in if runTests then crateWithTest drv testDrv testCrateFlags else drv)
+      { inherit features crateOverrides runTests testCrateFlags; };
 
   /* Returns a buildRustCrate derivation for the given packageId and features. */
-  builtRustCratesWithFeatures = { 
-        crateConfigs? crates, 
-        packageId,
-        features,
-        crateOverrides, 
-        buildRustCrateFunc
-      } @ args:
+  builtRustCratesWithFeatures =
+    { packageId
+    , features
+    , crateConfigs ? crates
+    , crateOverrides
+    , buildRustCrateFunc
+    , runTests
+    , target ? defaultTarget
+    } @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
+    assert (builtins.isBool runTests);
 
-    let mergedFeatures = mergePackageFeatures args;
+    let rootPackageId = packageId;
+        mergedFeatures = mergePackageFeatures (args // {
+          inherit rootPackageId;
+          target = target // { test = runTests; };
+        });
+
+        buildByPackageId = packageId: buildByPackageIdImpl packageId;
+
         # Memoize built packages so that reappearing packages are only built once.
         builtByPackageId =
           lib.mapAttrs (packageId: value: buildByPackageId packageId) crateConfigs;
-        buildByPackageId = packageId:
-          let features = mergedFeatures."${packageId}" or [];
-              crateConfig = lib.filterAttrs (n: v: n != "resolvedDefaultFeatures") crateConfigs."${packageId}";
+
+        buildByPackageIdImpl = packageId:
+          let
+              features = mergedFeatures."${packageId}" or [];
+              crateConfig' = crateConfigs."${packageId}";
+              crateConfig = builtins.removeAttrs crateConfig' ["resolvedDefaultFeatures" "devDependencies"];
+              devDependencies = lib.optionals (runTests && packageId == rootPackageId) (crateConfig'.devDependencies or []);
               dependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.dependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies =
+                   (crateConfig.dependencies or [])
+                    ++ devDependencies;
+                };
               buildDependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.buildDependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies = crateConfig.buildDependencies or [];
+                };
+
               dependenciesWithRenames =
-                lib.filter (d: d ? "rename")
-                  (crateConfig.buildDependencies or [] ++ crateConfig.dependencies or []);
+                lib.filter (d: d ? "rename") (
+                  (crateConfig.buildDependencies or [])
+                  ++ (crateConfig.dependencies or [])
+                  ++ devDependencies);
+
               crateRenames =
                 builtins.listToAttrs (map (d: { name = d.name; value = d.rename; }) dependenciesWithRenames);
-          in buildRustCrateFunc (crateConfig // { 
+          in buildRustCrateFunc (crateConfig // {
             src = crateConfig.src or (pkgs.fetchurl {
               name = "${crateConfig.crateName}-${crateConfig.version}.tar.gz";
               url = "https://crates.io/api/v1/crates/${crateConfig.crateName}/${crateConfig.version}/download";
               sha256 = crateConfig.sha256;
             });
-            inherit features dependencies buildDependencies crateRenames; 
+            inherit features dependencies buildDependencies crateRenames;
           });
     in builtByPackageId;
 
   /* Returns the actual derivations for the given dependencies. */
-  dependencyDerivations = builtByPackageId: features: dependencies:
+  dependencyDerivations =
+    { builtByPackageId
+    , features
+    , dependencies
+    , target
+    }:
     assert (builtins.isAttrs builtByPackageId);
     assert (builtins.isList features);
     assert (builtins.isList dependencies);
+    assert (builtins.isAttrs target);
 
-    let enabledDependencies = filterEnabledDependencies dependencies features;
+    let enabledDependencies = filterEnabledDependencies { inherit dependencies features target; };
         depDerivation = dependency: builtByPackageId.${dependency.packageId};
     in map depDerivation enabledDependencies;
 
@@ -1486,7 +1569,7 @@ rec {
           then "function"
           else val;
 
-  debugCrate = {packageId}:
+  debugCrate = {packageId, target}:
     assert (builtins.isString packageId);
 
     rec {
@@ -1504,7 +1587,7 @@ rec {
             };
             inherit packageId;
         });
-        mergedPackageFeatures = mergePackageFeatures { inherit packageId; features = rootFeatures; };
+        mergedPackageFeatures = mergePackageFeatures { inherit packageId target; features = rootFeatures; };
         diffedDefaultPackageFeatures = diffDefaultPackageFeatures { inherit packageId;  features = rootFeatures; };
     };
 
@@ -1512,14 +1595,18 @@ rec {
    *
    * This is useful for verifying the feature resolution in crate2nix.
    */
-  diffDefaultPackageFeatures = {crateConfigs ? crates, packageId}:
+  diffDefaultPackageFeatures =
+    { crateConfigs ? crates
+    , packageId
+    , target
+    }:
     assert (builtins.isAttrs crateConfigs);
 
     let prefixValues = prefix: lib.mapAttrs (n: v: { "${prefix}" = v; });
         mergedFeatures =
           prefixValues
             "crate2nix"
-            (mergePackageFeatures {inherit crateConfigs packageId; features = ["default"]; });
+            (mergePackageFeatures {inherit crateConfigs packageId target; features = ["default"]; });
         configs = prefixValues "cargo" crateConfigs;
         combined = lib.foldAttrs (a: b: a // b) {} [ mergedFeatures configs ];
         onlyInCargo = builtins.attrNames (lib.filterAttrs (n: v: !(v ? "crate2nix" ) && (v ? "cargo")) combined);
@@ -1540,12 +1627,16 @@ rec {
      Returns multiple, potentially conflicting attribute sets for dependencies that are reachable
      by multiple paths in the dependency tree.
   */
+
   mergePackageFeatures = {
     crateConfigs ? crates,
     packageId,
+    rootPackageId,
     features ? rootFeatures,
     dependencyPath? [crates.${packageId}.crateName],
     featuresByPackageId? {},
+    target,
+    runTests,
     ...} @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
@@ -1565,7 +1656,10 @@ rec {
           assert (builtins.isAttrs cache);
           assert (builtins.isList dependencies);
 
-          let enabledDependencies = filterEnabledDependencies dependencies expandedFeatures;
+          let enabledDependencies = filterEnabledDependencies {
+                inherit dependencies target;
+                features = expandedFeatures;
+              };
               directDependencies = map depWithResolvedFeatures enabledDependencies;
               foldOverCache = op: lib.foldl op cache directDependencies;
           in foldOverCache
@@ -1580,7 +1674,7 @@ rec {
                   dependencyPath = dependencyPath ++ [path crateConfigs.${packageId}.crateName];
                   features = combinedFeatures;
                   featuresByPackageId = cache;
-                  inherit crateConfigs packageId;
+                  inherit crateConfigs packageId target runTests rootPackageId;
                  });
 
         cacheWithSelf =
@@ -1591,21 +1685,25 @@ rec {
             };
 
         cacheWithDependencies =
-            resolveDependencies cacheWithSelf "dep" (crateConfig.dependencies or []);
+            resolveDependencies cacheWithSelf "dep" (
+              crateConfig.dependencies or []
+              ++ lib.optionals (runTests && packageId == rootPackageId) (crateConfig.devDependencies or [])
+        );
         cacheWithAll =
             resolveDependencies cacheWithDependencies "build" (crateConfig.buildDependencies or []);
 
     in cacheWithAll;
 
   /* Returns the enabled dependencies given the enabled features. */
-  filterEnabledDependencies = dependencies: features:
+  filterEnabledDependencies = {dependencies, features, target}:
     assert (builtins.isList dependencies);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
 
     lib.filter
       (dep:
         let targetFunc = dep.target or (features: true);
-        in targetFunc features
+        in targetFunc { inherit features target; }
            && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1606,15 +1606,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/sample_projects/bin_with_lib_git_dep/Cargo.nix
+++ b/sample_projects/bin_with_lib_git_dep/Cargo.nix
@@ -369,15 +369,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/sample_projects/bin_with_lib_git_dep/Cargo.nix
+++ b/sample_projects/bin_with_lib_git_dep/Cargo.nix
@@ -20,7 +20,7 @@ rec {
   #
 
   rootCrate = rec {
-    packageId = "bin_with_lib_git_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_lib_git_dep)";
+    packageId = "bin_with_lib_git_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_lib_git_dep)";
 
     # Use this attribute to refer to the derivation building your root crate package.
     # You can override the features with rootCrate.build.override { features = [ "default" "feature1" ... ]; }.
@@ -40,12 +40,12 @@ rec {
   # workspaceMembers."${crateName}".build.override { features = [ "default" "feature1" ... ]; }.
   workspaceMembers = {
     "bin_with_lib_git_dep" = rec {
-      packageId = "bin_with_lib_git_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_lib_git_dep)";
+      packageId = "bin_with_lib_git_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_lib_git_dep)";
       build = buildRustCrateWithFeatures {
-        packageId = "bin_with_lib_git_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_lib_git_dep)";
+        packageId = "bin_with_lib_git_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_lib_git_dep)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
@@ -68,9 +68,11 @@ rec {
   # * `dependencies`/`buildDependencies`: similar to the corresponding fields for buildRustCrate.
   #   but with additional information which is used during dependency/feature resolution.
   # * `resolvedDependencies`: the selected default features reported by cargo - only included for debugging.
+  # * `devDependencies` as of now not used by `buildRustCrate` but used to
+  #   inject test dependencies into the build
 
   crates = {
-    "bin_with_lib_git_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_lib_git_dep)"
+    "bin_with_lib_git_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_lib_git_dep)"
       = rec {
         crateName = "bin_with_lib_git_dep";
         version = "0.1.0";
@@ -115,11 +117,10 @@ rec {
 
   # Target (platform) data for conditional dependencies.
   # This corresponds roughly to what buildRustCrate is setting.
-  target = {
+  defaultTarget = {
       unix = true;
       windows = false;
       fuchsia = true;
-      # We don't support tests yet, so this is true for now.
       test = false;
 
       # This doesn't appear to be officially documented anywhere yet.
@@ -177,66 +178,138 @@ rec {
       baseName == "tests.nix"
     );
 
+  /* Returns a crate which depends on successful test execution of crate given as the second argument */
+  crateWithTest = crate: testCrate: testCrateFlags:
+    let
+      # override the `crate` so that it will build and execute tests instead of
+      # building the actual lib and bin targets We just have to pass `--test`
+      # to rustc and it will do the right thing.  We execute the tests and copy
+      # their log and the test executables to $out for later inspection.
+      test = let
+        drv = testCrate.override (_: {
+          buildTests = true;
+        });
+      in pkgs.runCommand "run-tests-${testCrate.name}" {
+        inherit testCrateFlags;
+      } ''
+        set -e
+        for file in ${drv}/tests/*; do
+          echo "Executing test $file" | tee -a $out
+          $file -- "$testCrateFlags" 2>&1 | tee -a $out
+        done
+      '';
+    in crate.overrideAttrs (old: {
+      checkPhase = ''
+        test -e ${test}
+      '';
+      passthru = (old.passthru or {}) // {
+        inherit test;
+      };
+    });
+
   /* A restricted overridable version of  buildRustCrateWithFeaturesImpl. */
-  buildRustCrateWithFeatures = {
-        packageId, 
-        features ? rootFeatures,
-        crateOverrides ? defaultCrateOverrides, 
-        buildRustCrateFunc ? buildRustCrate
-      }:
+  buildRustCrateWithFeatures =
+    { packageId
+    , features ? rootFeatures
+    , crateOverrides ? defaultCrateOverrides
+    , buildRustCrateFunc ? buildRustCrate
+    , runTests ? false
+    , testCrateFlags ? []
+    }:
     lib.makeOverridable
-      ({features, crateOverrides}: 
-        let builtRustCrates = builtRustCratesWithFeatures {
-          inherit packageId features crateOverrides  buildRustCrateFunc;
-        };
-        in builtRustCrates.${packageId})
-      { inherit features crateOverrides; };
+      ({features, crateOverrides, runTests, testCrateFlags}:
+        let
+          builtRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = false;
+          };
+          builtTestRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = true;
+          };
+          drv = builtRustCrates.${packageId};
+          testDrv = builtTestRustCrates.${packageId};
+        in if runTests then crateWithTest drv testDrv testCrateFlags else drv)
+      { inherit features crateOverrides runTests testCrateFlags; };
 
   /* Returns a buildRustCrate derivation for the given packageId and features. */
-  builtRustCratesWithFeatures = { 
-        crateConfigs? crates, 
-        packageId,
-        features,
-        crateOverrides, 
-        buildRustCrateFunc
-      } @ args:
+  builtRustCratesWithFeatures =
+    { packageId
+    , features
+    , crateConfigs ? crates
+    , crateOverrides
+    , buildRustCrateFunc
+    , runTests
+    , target ? defaultTarget
+    } @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
+    assert (builtins.isBool runTests);
 
-    let mergedFeatures = mergePackageFeatures args;
+    let rootPackageId = packageId;
+        mergedFeatures = mergePackageFeatures (args // {
+          inherit rootPackageId;
+          target = target // { test = runTests; };
+        });
+
+        buildByPackageId = packageId: buildByPackageIdImpl packageId;
+
         # Memoize built packages so that reappearing packages are only built once.
         builtByPackageId =
           lib.mapAttrs (packageId: value: buildByPackageId packageId) crateConfigs;
-        buildByPackageId = packageId:
-          let features = mergedFeatures."${packageId}" or [];
-              crateConfig = lib.filterAttrs (n: v: n != "resolvedDefaultFeatures") crateConfigs."${packageId}";
+
+        buildByPackageIdImpl = packageId:
+          let
+              features = mergedFeatures."${packageId}" or [];
+              crateConfig' = crateConfigs."${packageId}";
+              crateConfig = builtins.removeAttrs crateConfig' ["resolvedDefaultFeatures" "devDependencies"];
+              devDependencies = lib.optionals (runTests && packageId == rootPackageId) (crateConfig'.devDependencies or []);
               dependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.dependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies =
+                   (crateConfig.dependencies or [])
+                    ++ devDependencies;
+                };
               buildDependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.buildDependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies = crateConfig.buildDependencies or [];
+                };
+
               dependenciesWithRenames =
-                lib.filter (d: d ? "rename")
-                  (crateConfig.buildDependencies or [] ++ crateConfig.dependencies or []);
+                lib.filter (d: d ? "rename") (
+                  (crateConfig.buildDependencies or [])
+                  ++ (crateConfig.dependencies or [])
+                  ++ devDependencies);
+
               crateRenames =
                 builtins.listToAttrs (map (d: { name = d.name; value = d.rename; }) dependenciesWithRenames);
-          in buildRustCrateFunc (crateConfig // { 
+          in buildRustCrateFunc (crateConfig // {
             src = crateConfig.src or (pkgs.fetchurl {
               name = "${crateConfig.crateName}-${crateConfig.version}.tar.gz";
               url = "https://crates.io/api/v1/crates/${crateConfig.crateName}/${crateConfig.version}/download";
               sha256 = crateConfig.sha256;
             });
-            inherit features dependencies buildDependencies crateRenames; 
+            inherit features dependencies buildDependencies crateRenames;
           });
     in builtByPackageId;
 
   /* Returns the actual derivations for the given dependencies. */
-  dependencyDerivations = builtByPackageId: features: dependencies:
+  dependencyDerivations =
+    { builtByPackageId
+    , features
+    , dependencies
+    , target
+    }:
     assert (builtins.isAttrs builtByPackageId);
     assert (builtins.isList features);
     assert (builtins.isList dependencies);
+    assert (builtins.isAttrs target);
 
-    let enabledDependencies = filterEnabledDependencies dependencies features;
+    let enabledDependencies = filterEnabledDependencies { inherit dependencies features target; };
         depDerivation = dependency: builtByPackageId.${dependency.packageId};
     in map depDerivation enabledDependencies;
 
@@ -249,7 +322,7 @@ rec {
           then "function"
           else val;
 
-  debugCrate = {packageId}:
+  debugCrate = {packageId, target}:
     assert (builtins.isString packageId);
 
     rec {
@@ -267,7 +340,7 @@ rec {
             };
             inherit packageId;
         });
-        mergedPackageFeatures = mergePackageFeatures { inherit packageId; features = rootFeatures; };
+        mergedPackageFeatures = mergePackageFeatures { inherit packageId target; features = rootFeatures; };
         diffedDefaultPackageFeatures = diffDefaultPackageFeatures { inherit packageId;  features = rootFeatures; };
     };
 
@@ -275,14 +348,18 @@ rec {
    *
    * This is useful for verifying the feature resolution in crate2nix.
    */
-  diffDefaultPackageFeatures = {crateConfigs ? crates, packageId}:
+  diffDefaultPackageFeatures =
+    { crateConfigs ? crates
+    , packageId
+    , target
+    }:
     assert (builtins.isAttrs crateConfigs);
 
     let prefixValues = prefix: lib.mapAttrs (n: v: { "${prefix}" = v; });
         mergedFeatures =
           prefixValues
             "crate2nix"
-            (mergePackageFeatures {inherit crateConfigs packageId; features = ["default"]; });
+            (mergePackageFeatures {inherit crateConfigs packageId target; features = ["default"]; });
         configs = prefixValues "cargo" crateConfigs;
         combined = lib.foldAttrs (a: b: a // b) {} [ mergedFeatures configs ];
         onlyInCargo = builtins.attrNames (lib.filterAttrs (n: v: !(v ? "crate2nix" ) && (v ? "cargo")) combined);
@@ -303,12 +380,16 @@ rec {
      Returns multiple, potentially conflicting attribute sets for dependencies that are reachable
      by multiple paths in the dependency tree.
   */
+
   mergePackageFeatures = {
     crateConfigs ? crates,
     packageId,
+    rootPackageId,
     features ? rootFeatures,
     dependencyPath? [crates.${packageId}.crateName],
     featuresByPackageId? {},
+    target,
+    runTests,
     ...} @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
@@ -328,7 +409,10 @@ rec {
           assert (builtins.isAttrs cache);
           assert (builtins.isList dependencies);
 
-          let enabledDependencies = filterEnabledDependencies dependencies expandedFeatures;
+          let enabledDependencies = filterEnabledDependencies {
+                inherit dependencies target;
+                features = expandedFeatures;
+              };
               directDependencies = map depWithResolvedFeatures enabledDependencies;
               foldOverCache = op: lib.foldl op cache directDependencies;
           in foldOverCache
@@ -343,7 +427,7 @@ rec {
                   dependencyPath = dependencyPath ++ [path crateConfigs.${packageId}.crateName];
                   features = combinedFeatures;
                   featuresByPackageId = cache;
-                  inherit crateConfigs packageId;
+                  inherit crateConfigs packageId target runTests rootPackageId;
                  });
 
         cacheWithSelf =
@@ -354,21 +438,25 @@ rec {
             };
 
         cacheWithDependencies =
-            resolveDependencies cacheWithSelf "dep" (crateConfig.dependencies or []);
+            resolveDependencies cacheWithSelf "dep" (
+              crateConfig.dependencies or []
+              ++ lib.optionals (runTests && packageId == rootPackageId) (crateConfig.devDependencies or [])
+        );
         cacheWithAll =
             resolveDependencies cacheWithDependencies "build" (crateConfig.buildDependencies or []);
 
     in cacheWithAll;
 
   /* Returns the enabled dependencies given the enabled features. */
-  filterEnabledDependencies = dependencies: features:
+  filterEnabledDependencies = {dependencies, features, target}:
     assert (builtins.isList dependencies);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
 
     lib.filter
       (dep:
         let targetFunc = dep.target or (features: true);
-        in targetFunc features
+        in targetFunc { inherit features target; }
            && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 

--- a/sample_projects/bin_with_rerenamed_lib_dep/Cargo.lock
+++ b/sample_projects/bin_with_rerenamed_lib_dep/Cargo.lock
@@ -5,9 +5,14 @@ name = "bin_with_rerenamed_lib_dep"
 version = "0.1.0"
 dependencies = [
  "hello_world_lib 0.1.0",
+ "hello_world_lib_and_bin 0.1.0",
 ]
 
 [[package]]
 name = "hello_world_lib"
+version = "0.1.0"
+
+[[package]]
+name = "hello_world_lib_and_bin"
 version = "0.1.0"
 

--- a/sample_projects/bin_with_rerenamed_lib_dep/Cargo.nix
+++ b/sample_projects/bin_with_rerenamed_lib_dep/Cargo.nix
@@ -20,7 +20,7 @@ rec {
   #
 
   rootCrate = rec {
-    packageId = "bin_with_rerenamed_lib_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_rerenamed_lib_dep)";
+    packageId = "bin_with_rerenamed_lib_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_rerenamed_lib_dep)";
 
     # Use this attribute to refer to the derivation building your root crate package.
     # You can override the features with rootCrate.build.override { features = [ "default" "feature1" ... ]; }.
@@ -40,12 +40,12 @@ rec {
   # workspaceMembers."${crateName}".build.override { features = [ "default" "feature1" ... ]; }.
   workspaceMembers = {
     "bin_with_rerenamed_lib_dep" = rec {
-      packageId = "bin_with_rerenamed_lib_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_rerenamed_lib_dep)";
+      packageId = "bin_with_rerenamed_lib_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_rerenamed_lib_dep)";
       build = buildRustCrateWithFeatures {
-        packageId = "bin_with_rerenamed_lib_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_rerenamed_lib_dep)";
+        packageId = "bin_with_rerenamed_lib_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_rerenamed_lib_dep)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
@@ -68,9 +68,11 @@ rec {
   # * `dependencies`/`buildDependencies`: similar to the corresponding fields for buildRustCrate.
   #   but with additional information which is used during dependency/feature resolution.
   # * `resolvedDependencies`: the selected default features reported by cargo - only included for debugging.
+  # * `devDependencies` as of now not used by `buildRustCrate` but used to
+  #   inject test dependencies into the build
 
   crates = {
-    "bin_with_rerenamed_lib_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/bin_with_rerenamed_lib_dep)"
+    "bin_with_rerenamed_lib_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/bin_with_rerenamed_lib_dep)"
       = rec {
         crateName = "bin_with_rerenamed_lib_dep";
         version = "0.1.0";
@@ -85,12 +87,12 @@ rec {
         dependencies = [
           {
             name = "hello_world_lib";
-            packageId = "hello_world_lib 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/lib)";
+            packageId = "hello_world_lib 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/lib)";
             rename = "new_name_hello_world_lib";
           }
           {
             name = "hello_world_lib_and_bin";
-            packageId = "hello_world_lib_and_bin 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/lib_and_bin)";
+            packageId = "hello_world_lib_and_bin 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/lib_and_bin)";
             rename = "feature_hello_world_lib_and_bin";
             optional = true;
           }
@@ -101,7 +103,7 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "enable_renamed_crate" "feature_hello_world_lib_and_bin" ];
       };
-    "hello_world_lib 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/lib)"
+    "hello_world_lib 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/lib)"
       = rec {
         crateName = "hello_world_lib";
         version = "0.1.0";
@@ -114,7 +116,7 @@ rec {
         features = {
         };
       };
-    "hello_world_lib_and_bin 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/lib_and_bin)"
+    "hello_world_lib_and_bin 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/lib_and_bin)"
       = rec {
         crateName = "hello_world_lib_and_bin";
         version = "0.1.0";
@@ -136,11 +138,10 @@ rec {
 
   # Target (platform) data for conditional dependencies.
   # This corresponds roughly to what buildRustCrate is setting.
-  target = {
+  defaultTarget = {
       unix = true;
       windows = false;
       fuchsia = true;
-      # We don't support tests yet, so this is true for now.
       test = false;
 
       # This doesn't appear to be officially documented anywhere yet.
@@ -198,66 +199,138 @@ rec {
       baseName == "tests.nix"
     );
 
+  /* Returns a crate which depends on successful test execution of crate given as the second argument */
+  crateWithTest = crate: testCrate: testCrateFlags:
+    let
+      # override the `crate` so that it will build and execute tests instead of
+      # building the actual lib and bin targets We just have to pass `--test`
+      # to rustc and it will do the right thing.  We execute the tests and copy
+      # their log and the test executables to $out for later inspection.
+      test = let
+        drv = testCrate.override (_: {
+          buildTests = true;
+        });
+      in pkgs.runCommand "run-tests-${testCrate.name}" {
+        inherit testCrateFlags;
+      } ''
+        set -e
+        for file in ${drv}/tests/*; do
+          echo "Executing test $file" | tee -a $out
+          $file -- "$testCrateFlags" 2>&1 | tee -a $out
+        done
+      '';
+    in crate.overrideAttrs (old: {
+      checkPhase = ''
+        test -e ${test}
+      '';
+      passthru = (old.passthru or {}) // {
+        inherit test;
+      };
+    });
+
   /* A restricted overridable version of  buildRustCrateWithFeaturesImpl. */
-  buildRustCrateWithFeatures = {
-        packageId, 
-        features ? rootFeatures,
-        crateOverrides ? defaultCrateOverrides, 
-        buildRustCrateFunc ? buildRustCrate
-      }:
+  buildRustCrateWithFeatures =
+    { packageId
+    , features ? rootFeatures
+    , crateOverrides ? defaultCrateOverrides
+    , buildRustCrateFunc ? buildRustCrate
+    , runTests ? false
+    , testCrateFlags ? []
+    }:
     lib.makeOverridable
-      ({features, crateOverrides}: 
-        let builtRustCrates = builtRustCratesWithFeatures {
-          inherit packageId features crateOverrides  buildRustCrateFunc;
-        };
-        in builtRustCrates.${packageId})
-      { inherit features crateOverrides; };
+      ({features, crateOverrides, runTests, testCrateFlags}:
+        let
+          builtRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = false;
+          };
+          builtTestRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = true;
+          };
+          drv = builtRustCrates.${packageId};
+          testDrv = builtTestRustCrates.${packageId};
+        in if runTests then crateWithTest drv testDrv testCrateFlags else drv)
+      { inherit features crateOverrides runTests testCrateFlags; };
 
   /* Returns a buildRustCrate derivation for the given packageId and features. */
-  builtRustCratesWithFeatures = { 
-        crateConfigs? crates, 
-        packageId,
-        features,
-        crateOverrides, 
-        buildRustCrateFunc
-      } @ args:
+  builtRustCratesWithFeatures =
+    { packageId
+    , features
+    , crateConfigs ? crates
+    , crateOverrides
+    , buildRustCrateFunc
+    , runTests
+    , target ? defaultTarget
+    } @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
+    assert (builtins.isBool runTests);
 
-    let mergedFeatures = mergePackageFeatures args;
+    let rootPackageId = packageId;
+        mergedFeatures = mergePackageFeatures (args // {
+          inherit rootPackageId;
+          target = target // { test = runTests; };
+        });
+
+        buildByPackageId = packageId: buildByPackageIdImpl packageId;
+
         # Memoize built packages so that reappearing packages are only built once.
         builtByPackageId =
           lib.mapAttrs (packageId: value: buildByPackageId packageId) crateConfigs;
-        buildByPackageId = packageId:
-          let features = mergedFeatures."${packageId}" or [];
-              crateConfig = lib.filterAttrs (n: v: n != "resolvedDefaultFeatures") crateConfigs."${packageId}";
+
+        buildByPackageIdImpl = packageId:
+          let
+              features = mergedFeatures."${packageId}" or [];
+              crateConfig' = crateConfigs."${packageId}";
+              crateConfig = builtins.removeAttrs crateConfig' ["resolvedDefaultFeatures" "devDependencies"];
+              devDependencies = lib.optionals (runTests && packageId == rootPackageId) (crateConfig'.devDependencies or []);
               dependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.dependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies =
+                   (crateConfig.dependencies or [])
+                    ++ devDependencies;
+                };
               buildDependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.buildDependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies = crateConfig.buildDependencies or [];
+                };
+
               dependenciesWithRenames =
-                lib.filter (d: d ? "rename")
-                  (crateConfig.buildDependencies or [] ++ crateConfig.dependencies or []);
+                lib.filter (d: d ? "rename") (
+                  (crateConfig.buildDependencies or [])
+                  ++ (crateConfig.dependencies or [])
+                  ++ devDependencies);
+
               crateRenames =
                 builtins.listToAttrs (map (d: { name = d.name; value = d.rename; }) dependenciesWithRenames);
-          in buildRustCrateFunc (crateConfig // { 
+          in buildRustCrateFunc (crateConfig // {
             src = crateConfig.src or (pkgs.fetchurl {
               name = "${crateConfig.crateName}-${crateConfig.version}.tar.gz";
               url = "https://crates.io/api/v1/crates/${crateConfig.crateName}/${crateConfig.version}/download";
               sha256 = crateConfig.sha256;
             });
-            inherit features dependencies buildDependencies crateRenames; 
+            inherit features dependencies buildDependencies crateRenames;
           });
     in builtByPackageId;
 
   /* Returns the actual derivations for the given dependencies. */
-  dependencyDerivations = builtByPackageId: features: dependencies:
+  dependencyDerivations =
+    { builtByPackageId
+    , features
+    , dependencies
+    , target
+    }:
     assert (builtins.isAttrs builtByPackageId);
     assert (builtins.isList features);
     assert (builtins.isList dependencies);
+    assert (builtins.isAttrs target);
 
-    let enabledDependencies = filterEnabledDependencies dependencies features;
+    let enabledDependencies = filterEnabledDependencies { inherit dependencies features target; };
         depDerivation = dependency: builtByPackageId.${dependency.packageId};
     in map depDerivation enabledDependencies;
 
@@ -270,7 +343,7 @@ rec {
           then "function"
           else val;
 
-  debugCrate = {packageId}:
+  debugCrate = {packageId, target}:
     assert (builtins.isString packageId);
 
     rec {
@@ -288,7 +361,7 @@ rec {
             };
             inherit packageId;
         });
-        mergedPackageFeatures = mergePackageFeatures { inherit packageId; features = rootFeatures; };
+        mergedPackageFeatures = mergePackageFeatures { inherit packageId target; features = rootFeatures; };
         diffedDefaultPackageFeatures = diffDefaultPackageFeatures { inherit packageId;  features = rootFeatures; };
     };
 
@@ -296,14 +369,18 @@ rec {
    *
    * This is useful for verifying the feature resolution in crate2nix.
    */
-  diffDefaultPackageFeatures = {crateConfigs ? crates, packageId}:
+  diffDefaultPackageFeatures =
+    { crateConfigs ? crates
+    , packageId
+    , target
+    }:
     assert (builtins.isAttrs crateConfigs);
 
     let prefixValues = prefix: lib.mapAttrs (n: v: { "${prefix}" = v; });
         mergedFeatures =
           prefixValues
             "crate2nix"
-            (mergePackageFeatures {inherit crateConfigs packageId; features = ["default"]; });
+            (mergePackageFeatures {inherit crateConfigs packageId target; features = ["default"]; });
         configs = prefixValues "cargo" crateConfigs;
         combined = lib.foldAttrs (a: b: a // b) {} [ mergedFeatures configs ];
         onlyInCargo = builtins.attrNames (lib.filterAttrs (n: v: !(v ? "crate2nix" ) && (v ? "cargo")) combined);
@@ -324,12 +401,16 @@ rec {
      Returns multiple, potentially conflicting attribute sets for dependencies that are reachable
      by multiple paths in the dependency tree.
   */
+
   mergePackageFeatures = {
     crateConfigs ? crates,
     packageId,
+    rootPackageId,
     features ? rootFeatures,
     dependencyPath? [crates.${packageId}.crateName],
     featuresByPackageId? {},
+    target,
+    runTests,
     ...} @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
@@ -349,7 +430,10 @@ rec {
           assert (builtins.isAttrs cache);
           assert (builtins.isList dependencies);
 
-          let enabledDependencies = filterEnabledDependencies dependencies expandedFeatures;
+          let enabledDependencies = filterEnabledDependencies {
+                inherit dependencies target;
+                features = expandedFeatures;
+              };
               directDependencies = map depWithResolvedFeatures enabledDependencies;
               foldOverCache = op: lib.foldl op cache directDependencies;
           in foldOverCache
@@ -364,7 +448,7 @@ rec {
                   dependencyPath = dependencyPath ++ [path crateConfigs.${packageId}.crateName];
                   features = combinedFeatures;
                   featuresByPackageId = cache;
-                  inherit crateConfigs packageId;
+                  inherit crateConfigs packageId target runTests rootPackageId;
                  });
 
         cacheWithSelf =
@@ -375,21 +459,25 @@ rec {
             };
 
         cacheWithDependencies =
-            resolveDependencies cacheWithSelf "dep" (crateConfig.dependencies or []);
+            resolveDependencies cacheWithSelf "dep" (
+              crateConfig.dependencies or []
+              ++ lib.optionals (runTests && packageId == rootPackageId) (crateConfig.devDependencies or [])
+        );
         cacheWithAll =
             resolveDependencies cacheWithDependencies "build" (crateConfig.buildDependencies or []);
 
     in cacheWithAll;
 
   /* Returns the enabled dependencies given the enabled features. */
-  filterEnabledDependencies = dependencies: features:
+  filterEnabledDependencies = {dependencies, features, target}:
     assert (builtins.isList dependencies);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
 
     lib.filter
       (dep:
         let targetFunc = dep.target or (features: true);
-        in targetFunc features
+        in targetFunc { inherit features target; }
            && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 

--- a/sample_projects/bin_with_rerenamed_lib_dep/Cargo.toml
+++ b/sample_projects/bin_with_rerenamed_lib_dep/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2018"
 
 [dependencies]
 "new_name_hello_world_lib" = { package = "hello_world_lib", path = "../lib"}
+"feature_hello_world_lib_and_bin" = { package = "hello_world_lib_and_bin", path = "../lib_and_bin", optional = true}
+
+[features]
+default = [ "enable_renamed_crate" ]
+enable_renamed_crate = [ "feature_hello_world_lib_and_bin" ]

--- a/sample_projects/cfg-test/Cargo.nix
+++ b/sample_projects/cfg-test/Cargo.nix
@@ -20,7 +20,7 @@ rec {
   #
 
   rootCrate = rec {
-    packageId = "cfg-test 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/cfg-test)";
+    packageId = "cfg-test 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/cfg-test)";
 
     # Use this attribute to refer to the derivation building your root crate package.
     # You can override the features with rootCrate.build.override { features = [ "default" "feature1" ... ]; }.
@@ -40,12 +40,12 @@ rec {
   # workspaceMembers."${crateName}".build.override { features = [ "default" "feature1" ... ]; }.
   workspaceMembers = {
     "cfg-test" = rec {
-      packageId = "cfg-test 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/cfg-test)";
+      packageId = "cfg-test 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/cfg-test)";
       build = buildRustCrateWithFeatures {
-        packageId = "cfg-test 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/cfg-test)";
+        packageId = "cfg-test 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/cfg-test)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
@@ -68,6 +68,8 @@ rec {
   # * `dependencies`/`buildDependencies`: similar to the corresponding fields for buildRustCrate.
   #   but with additional information which is used during dependency/feature resolution.
   # * `resolvedDependencies`: the selected default features reported by cargo - only included for debugging.
+  # * `devDependencies` as of now not used by `buildRustCrate` but used to
+  #   inject test dependencies into the build
 
   crates = {
     "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)"
@@ -83,7 +85,7 @@ rec {
           "rustc-dep-of-std" = [ "core" "compiler_builtins" ];
         };
       };
-    "cfg-test 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/cfg-test)"
+    "cfg-test 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/cfg-test)"
       = rec {
         crateName = "cfg-test";
         version = "0.1.0";
@@ -99,7 +101,7 @@ rec {
           {
             name = "tracing";
             packageId = "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."test";
+            target = {target, features}: target."test";
             features = [ "log" ];
           }
         ];
@@ -256,7 +258,7 @@ rec {
           {
             name = "spin";
             packageId = "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (!(builtins.elem "std" features));
+            target = {target, features}: (!(builtins.elem "std" features));
           }
           {
             name = "tracing-attributes";
@@ -266,6 +268,12 @@ rec {
             name = "tracing-core";
             packageId = "tracing-core 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
+          }
+        ];
+        devDependencies = [
+          {
+            name = "log";
+            packageId = "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)";
           }
         ];
         features = {
@@ -318,13 +326,13 @@ rec {
           {
             name = "lazy_static";
             packageId = "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (!(builtins.elem "std" features));
+            target = {target, features}: (!(builtins.elem "std" features));
             features = [ "spin_no_std" ];
           }
           {
             name = "spin";
             packageId = "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (!(builtins.elem "std" features));
+            target = {target, features}: (!(builtins.elem "std" features));
           }
         ];
         features = {
@@ -354,11 +362,10 @@ rec {
 
   # Target (platform) data for conditional dependencies.
   # This corresponds roughly to what buildRustCrate is setting.
-  target = {
+  defaultTarget = {
       unix = true;
       windows = false;
       fuchsia = true;
-      # We don't support tests yet, so this is true for now.
       test = false;
 
       # This doesn't appear to be officially documented anywhere yet.
@@ -416,66 +423,138 @@ rec {
       baseName == "tests.nix"
     );
 
+  /* Returns a crate which depends on successful test execution of crate given as the second argument */
+  crateWithTest = crate: testCrate: testCrateFlags:
+    let
+      # override the `crate` so that it will build and execute tests instead of
+      # building the actual lib and bin targets We just have to pass `--test`
+      # to rustc and it will do the right thing.  We execute the tests and copy
+      # their log and the test executables to $out for later inspection.
+      test = let
+        drv = testCrate.override (_: {
+          buildTests = true;
+        });
+      in pkgs.runCommand "run-tests-${testCrate.name}" {
+        inherit testCrateFlags;
+      } ''
+        set -e
+        for file in ${drv}/tests/*; do
+          echo "Executing test $file" | tee -a $out
+          $file -- "$testCrateFlags" 2>&1 | tee -a $out
+        done
+      '';
+    in crate.overrideAttrs (old: {
+      checkPhase = ''
+        test -e ${test}
+      '';
+      passthru = (old.passthru or {}) // {
+        inherit test;
+      };
+    });
+
   /* A restricted overridable version of  buildRustCrateWithFeaturesImpl. */
-  buildRustCrateWithFeatures = {
-        packageId, 
-        features ? rootFeatures,
-        crateOverrides ? defaultCrateOverrides, 
-        buildRustCrateFunc ? buildRustCrate
-      }:
+  buildRustCrateWithFeatures =
+    { packageId
+    , features ? rootFeatures
+    , crateOverrides ? defaultCrateOverrides
+    , buildRustCrateFunc ? buildRustCrate
+    , runTests ? false
+    , testCrateFlags ? []
+    }:
     lib.makeOverridable
-      ({features, crateOverrides}: 
-        let builtRustCrates = builtRustCratesWithFeatures {
-          inherit packageId features crateOverrides  buildRustCrateFunc;
-        };
-        in builtRustCrates.${packageId})
-      { inherit features crateOverrides; };
+      ({features, crateOverrides, runTests, testCrateFlags}:
+        let
+          builtRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = false;
+          };
+          builtTestRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = true;
+          };
+          drv = builtRustCrates.${packageId};
+          testDrv = builtTestRustCrates.${packageId};
+        in if runTests then crateWithTest drv testDrv testCrateFlags else drv)
+      { inherit features crateOverrides runTests testCrateFlags; };
 
   /* Returns a buildRustCrate derivation for the given packageId and features. */
-  builtRustCratesWithFeatures = { 
-        crateConfigs? crates, 
-        packageId,
-        features,
-        crateOverrides, 
-        buildRustCrateFunc
-      } @ args:
+  builtRustCratesWithFeatures =
+    { packageId
+    , features
+    , crateConfigs ? crates
+    , crateOverrides
+    , buildRustCrateFunc
+    , runTests
+    , target ? defaultTarget
+    } @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
+    assert (builtins.isBool runTests);
 
-    let mergedFeatures = mergePackageFeatures args;
+    let rootPackageId = packageId;
+        mergedFeatures = mergePackageFeatures (args // {
+          inherit rootPackageId;
+          target = target // { test = runTests; };
+        });
+
+        buildByPackageId = packageId: buildByPackageIdImpl packageId;
+
         # Memoize built packages so that reappearing packages are only built once.
         builtByPackageId =
           lib.mapAttrs (packageId: value: buildByPackageId packageId) crateConfigs;
-        buildByPackageId = packageId:
-          let features = mergedFeatures."${packageId}" or [];
-              crateConfig = lib.filterAttrs (n: v: n != "resolvedDefaultFeatures") crateConfigs."${packageId}";
+
+        buildByPackageIdImpl = packageId:
+          let
+              features = mergedFeatures."${packageId}" or [];
+              crateConfig' = crateConfigs."${packageId}";
+              crateConfig = builtins.removeAttrs crateConfig' ["resolvedDefaultFeatures" "devDependencies"];
+              devDependencies = lib.optionals (runTests && packageId == rootPackageId) (crateConfig'.devDependencies or []);
               dependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.dependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies =
+                   (crateConfig.dependencies or [])
+                    ++ devDependencies;
+                };
               buildDependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.buildDependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies = crateConfig.buildDependencies or [];
+                };
+
               dependenciesWithRenames =
-                lib.filter (d: d ? "rename")
-                  (crateConfig.buildDependencies or [] ++ crateConfig.dependencies or []);
+                lib.filter (d: d ? "rename") (
+                  (crateConfig.buildDependencies or [])
+                  ++ (crateConfig.dependencies or [])
+                  ++ devDependencies);
+
               crateRenames =
                 builtins.listToAttrs (map (d: { name = d.name; value = d.rename; }) dependenciesWithRenames);
-          in buildRustCrateFunc (crateConfig // { 
+          in buildRustCrateFunc (crateConfig // {
             src = crateConfig.src or (pkgs.fetchurl {
               name = "${crateConfig.crateName}-${crateConfig.version}.tar.gz";
               url = "https://crates.io/api/v1/crates/${crateConfig.crateName}/${crateConfig.version}/download";
               sha256 = crateConfig.sha256;
             });
-            inherit features dependencies buildDependencies crateRenames; 
+            inherit features dependencies buildDependencies crateRenames;
           });
     in builtByPackageId;
 
   /* Returns the actual derivations for the given dependencies. */
-  dependencyDerivations = builtByPackageId: features: dependencies:
+  dependencyDerivations =
+    { builtByPackageId
+    , features
+    , dependencies
+    , target
+    }:
     assert (builtins.isAttrs builtByPackageId);
     assert (builtins.isList features);
     assert (builtins.isList dependencies);
+    assert (builtins.isAttrs target);
 
-    let enabledDependencies = filterEnabledDependencies dependencies features;
+    let enabledDependencies = filterEnabledDependencies { inherit dependencies features target; };
         depDerivation = dependency: builtByPackageId.${dependency.packageId};
     in map depDerivation enabledDependencies;
 
@@ -488,7 +567,7 @@ rec {
           then "function"
           else val;
 
-  debugCrate = {packageId}:
+  debugCrate = {packageId, target}:
     assert (builtins.isString packageId);
 
     rec {
@@ -506,7 +585,7 @@ rec {
             };
             inherit packageId;
         });
-        mergedPackageFeatures = mergePackageFeatures { inherit packageId; features = rootFeatures; };
+        mergedPackageFeatures = mergePackageFeatures { inherit packageId target; features = rootFeatures; };
         diffedDefaultPackageFeatures = diffDefaultPackageFeatures { inherit packageId;  features = rootFeatures; };
     };
 
@@ -514,14 +593,18 @@ rec {
    *
    * This is useful for verifying the feature resolution in crate2nix.
    */
-  diffDefaultPackageFeatures = {crateConfigs ? crates, packageId}:
+  diffDefaultPackageFeatures =
+    { crateConfigs ? crates
+    , packageId
+    , target
+    }:
     assert (builtins.isAttrs crateConfigs);
 
     let prefixValues = prefix: lib.mapAttrs (n: v: { "${prefix}" = v; });
         mergedFeatures =
           prefixValues
             "crate2nix"
-            (mergePackageFeatures {inherit crateConfigs packageId; features = ["default"]; });
+            (mergePackageFeatures {inherit crateConfigs packageId target; features = ["default"]; });
         configs = prefixValues "cargo" crateConfigs;
         combined = lib.foldAttrs (a: b: a // b) {} [ mergedFeatures configs ];
         onlyInCargo = builtins.attrNames (lib.filterAttrs (n: v: !(v ? "crate2nix" ) && (v ? "cargo")) combined);
@@ -542,12 +625,16 @@ rec {
      Returns multiple, potentially conflicting attribute sets for dependencies that are reachable
      by multiple paths in the dependency tree.
   */
+
   mergePackageFeatures = {
     crateConfigs ? crates,
     packageId,
+    rootPackageId,
     features ? rootFeatures,
     dependencyPath? [crates.${packageId}.crateName],
     featuresByPackageId? {},
+    target,
+    runTests,
     ...} @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
@@ -567,7 +654,10 @@ rec {
           assert (builtins.isAttrs cache);
           assert (builtins.isList dependencies);
 
-          let enabledDependencies = filterEnabledDependencies dependencies expandedFeatures;
+          let enabledDependencies = filterEnabledDependencies {
+                inherit dependencies target;
+                features = expandedFeatures;
+              };
               directDependencies = map depWithResolvedFeatures enabledDependencies;
               foldOverCache = op: lib.foldl op cache directDependencies;
           in foldOverCache
@@ -582,7 +672,7 @@ rec {
                   dependencyPath = dependencyPath ++ [path crateConfigs.${packageId}.crateName];
                   features = combinedFeatures;
                   featuresByPackageId = cache;
-                  inherit crateConfigs packageId;
+                  inherit crateConfigs packageId target runTests rootPackageId;
                  });
 
         cacheWithSelf =
@@ -593,21 +683,25 @@ rec {
             };
 
         cacheWithDependencies =
-            resolveDependencies cacheWithSelf "dep" (crateConfig.dependencies or []);
+            resolveDependencies cacheWithSelf "dep" (
+              crateConfig.dependencies or []
+              ++ lib.optionals (runTests && packageId == rootPackageId) (crateConfig.devDependencies or [])
+        );
         cacheWithAll =
             resolveDependencies cacheWithDependencies "build" (crateConfig.buildDependencies or []);
 
     in cacheWithAll;
 
   /* Returns the enabled dependencies given the enabled features. */
-  filterEnabledDependencies = dependencies: features:
+  filterEnabledDependencies = {dependencies, features, target}:
     assert (builtins.isList dependencies);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
 
     lib.filter
       (dep:
         let targetFunc = dep.target or (features: true);
-        in targetFunc features
+        in targetFunc { inherit features target; }
            && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 

--- a/sample_projects/cfg-test/Cargo.nix
+++ b/sample_projects/cfg-test/Cargo.nix
@@ -608,15 +608,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/sample_projects/cfg-test/src/lib.rs
+++ b/sample_projects/cfg-test/src/lib.rs
@@ -1,0 +1,6 @@
+
+#[cfg(test)]
+#[test]
+fn lib_test() {
+    println!("lib test executed");
+}

--- a/sample_projects/cfg-test/test.nix
+++ b/sample_projects/cfg-test/test.nix
@@ -1,5 +1,5 @@
 { pkgs? import ../../nixpkgs.nix { config = {}; } }:
 let
   basePackage = pkgs.callPackage ./Cargo.nix { };
-  submodulePackage = basePackage.rootCrate.build.override { doTest = true; };
+  submodulePackage = basePackage.rootCrate.build.override { runTests = true; };
 in submodulePackage

--- a/sample_projects/cfg-test/test.nix
+++ b/sample_projects/cfg-test/test.nix
@@ -1,0 +1,5 @@
+{ pkgs? import ../../nixpkgs.nix { config = {}; } }:
+let
+  basePackage = pkgs.callPackage ./Cargo.nix { };
+  submodulePackage = basePackage.rootCrate.build.override { doTest = true; };
+in submodulePackage

--- a/sample_projects/cfg-test/tests/echo_foo_test.rs
+++ b/sample_projects/cfg-test/tests/echo_foo_test.rs
@@ -1,0 +1,4 @@
+#[test]
+fn echo_foo_test() {
+    println!("echo_foo_test");
+}

--- a/sample_projects/numtest/Cargo.nix
+++ b/sample_projects/numtest/Cargo.nix
@@ -604,15 +604,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/sample_projects/numtest/Cargo.nix
+++ b/sample_projects/numtest/Cargo.nix
@@ -20,7 +20,7 @@ rec {
   #
 
   rootCrate = rec {
-    packageId = "numtest 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/numtest)";
+    packageId = "numtest 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/numtest)";
 
     # Use this attribute to refer to the derivation building your root crate package.
     # You can override the features with rootCrate.build.override { features = [ "default" "feature1" ... ]; }.
@@ -40,12 +40,12 @@ rec {
   # workspaceMembers."${crateName}".build.override { features = [ "default" "feature1" ... ]; }.
   workspaceMembers = {
     "numtest" = rec {
-      packageId = "numtest 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/numtest)";
+      packageId = "numtest 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/numtest)";
       build = buildRustCrateWithFeatures {
-        packageId = "numtest 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/numtest)";
+        packageId = "numtest 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/numtest)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
@@ -68,6 +68,8 @@ rec {
   # * `dependencies`/`buildDependencies`: similar to the corresponding fields for buildRustCrate.
   #   but with additional information which is used during dependency/feature resolution.
   # * `resolvedDependencies`: the selected default features reported by cargo - only included for debugging.
+  # * `devDependencies` as of now not used by `buildRustCrate` but used to
+  #   inject test dependencies into the build
 
   crates = {
     "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)"
@@ -321,7 +323,7 @@ rec {
         };
         resolvedDefaultFeatures = [ "std" ];
       };
-    "numtest 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/numtest)"
+    "numtest 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/numtest)"
       = rec {
         crateName = "numtest";
         version = "0.1.0";
@@ -350,11 +352,10 @@ rec {
 
   # Target (platform) data for conditional dependencies.
   # This corresponds roughly to what buildRustCrate is setting.
-  target = {
+  defaultTarget = {
       unix = true;
       windows = false;
       fuchsia = true;
-      # We don't support tests yet, so this is true for now.
       test = false;
 
       # This doesn't appear to be officially documented anywhere yet.
@@ -412,66 +413,138 @@ rec {
       baseName == "tests.nix"
     );
 
+  /* Returns a crate which depends on successful test execution of crate given as the second argument */
+  crateWithTest = crate: testCrate: testCrateFlags:
+    let
+      # override the `crate` so that it will build and execute tests instead of
+      # building the actual lib and bin targets We just have to pass `--test`
+      # to rustc and it will do the right thing.  We execute the tests and copy
+      # their log and the test executables to $out for later inspection.
+      test = let
+        drv = testCrate.override (_: {
+          buildTests = true;
+        });
+      in pkgs.runCommand "run-tests-${testCrate.name}" {
+        inherit testCrateFlags;
+      } ''
+        set -e
+        for file in ${drv}/tests/*; do
+          echo "Executing test $file" | tee -a $out
+          $file -- "$testCrateFlags" 2>&1 | tee -a $out
+        done
+      '';
+    in crate.overrideAttrs (old: {
+      checkPhase = ''
+        test -e ${test}
+      '';
+      passthru = (old.passthru or {}) // {
+        inherit test;
+      };
+    });
+
   /* A restricted overridable version of  buildRustCrateWithFeaturesImpl. */
-  buildRustCrateWithFeatures = {
-        packageId, 
-        features ? rootFeatures,
-        crateOverrides ? defaultCrateOverrides, 
-        buildRustCrateFunc ? buildRustCrate
-      }:
+  buildRustCrateWithFeatures =
+    { packageId
+    , features ? rootFeatures
+    , crateOverrides ? defaultCrateOverrides
+    , buildRustCrateFunc ? buildRustCrate
+    , runTests ? false
+    , testCrateFlags ? []
+    }:
     lib.makeOverridable
-      ({features, crateOverrides}: 
-        let builtRustCrates = builtRustCratesWithFeatures {
-          inherit packageId features crateOverrides  buildRustCrateFunc;
-        };
-        in builtRustCrates.${packageId})
-      { inherit features crateOverrides; };
+      ({features, crateOverrides, runTests, testCrateFlags}:
+        let
+          builtRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = false;
+          };
+          builtTestRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = true;
+          };
+          drv = builtRustCrates.${packageId};
+          testDrv = builtTestRustCrates.${packageId};
+        in if runTests then crateWithTest drv testDrv testCrateFlags else drv)
+      { inherit features crateOverrides runTests testCrateFlags; };
 
   /* Returns a buildRustCrate derivation for the given packageId and features. */
-  builtRustCratesWithFeatures = { 
-        crateConfigs? crates, 
-        packageId,
-        features,
-        crateOverrides, 
-        buildRustCrateFunc
-      } @ args:
+  builtRustCratesWithFeatures =
+    { packageId
+    , features
+    , crateConfigs ? crates
+    , crateOverrides
+    , buildRustCrateFunc
+    , runTests
+    , target ? defaultTarget
+    } @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
+    assert (builtins.isBool runTests);
 
-    let mergedFeatures = mergePackageFeatures args;
+    let rootPackageId = packageId;
+        mergedFeatures = mergePackageFeatures (args // {
+          inherit rootPackageId;
+          target = target // { test = runTests; };
+        });
+
+        buildByPackageId = packageId: buildByPackageIdImpl packageId;
+
         # Memoize built packages so that reappearing packages are only built once.
         builtByPackageId =
           lib.mapAttrs (packageId: value: buildByPackageId packageId) crateConfigs;
-        buildByPackageId = packageId:
-          let features = mergedFeatures."${packageId}" or [];
-              crateConfig = lib.filterAttrs (n: v: n != "resolvedDefaultFeatures") crateConfigs."${packageId}";
+
+        buildByPackageIdImpl = packageId:
+          let
+              features = mergedFeatures."${packageId}" or [];
+              crateConfig' = crateConfigs."${packageId}";
+              crateConfig = builtins.removeAttrs crateConfig' ["resolvedDefaultFeatures" "devDependencies"];
+              devDependencies = lib.optionals (runTests && packageId == rootPackageId) (crateConfig'.devDependencies or []);
               dependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.dependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies =
+                   (crateConfig.dependencies or [])
+                    ++ devDependencies;
+                };
               buildDependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.buildDependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies = crateConfig.buildDependencies or [];
+                };
+
               dependenciesWithRenames =
-                lib.filter (d: d ? "rename")
-                  (crateConfig.buildDependencies or [] ++ crateConfig.dependencies or []);
+                lib.filter (d: d ? "rename") (
+                  (crateConfig.buildDependencies or [])
+                  ++ (crateConfig.dependencies or [])
+                  ++ devDependencies);
+
               crateRenames =
                 builtins.listToAttrs (map (d: { name = d.name; value = d.rename; }) dependenciesWithRenames);
-          in buildRustCrateFunc (crateConfig // { 
+          in buildRustCrateFunc (crateConfig // {
             src = crateConfig.src or (pkgs.fetchurl {
               name = "${crateConfig.crateName}-${crateConfig.version}.tar.gz";
               url = "https://crates.io/api/v1/crates/${crateConfig.crateName}/${crateConfig.version}/download";
               sha256 = crateConfig.sha256;
             });
-            inherit features dependencies buildDependencies crateRenames; 
+            inherit features dependencies buildDependencies crateRenames;
           });
     in builtByPackageId;
 
   /* Returns the actual derivations for the given dependencies. */
-  dependencyDerivations = builtByPackageId: features: dependencies:
+  dependencyDerivations =
+    { builtByPackageId
+    , features
+    , dependencies
+    , target
+    }:
     assert (builtins.isAttrs builtByPackageId);
     assert (builtins.isList features);
     assert (builtins.isList dependencies);
+    assert (builtins.isAttrs target);
 
-    let enabledDependencies = filterEnabledDependencies dependencies features;
+    let enabledDependencies = filterEnabledDependencies { inherit dependencies features target; };
         depDerivation = dependency: builtByPackageId.${dependency.packageId};
     in map depDerivation enabledDependencies;
 
@@ -484,7 +557,7 @@ rec {
           then "function"
           else val;
 
-  debugCrate = {packageId}:
+  debugCrate = {packageId, target}:
     assert (builtins.isString packageId);
 
     rec {
@@ -502,7 +575,7 @@ rec {
             };
             inherit packageId;
         });
-        mergedPackageFeatures = mergePackageFeatures { inherit packageId; features = rootFeatures; };
+        mergedPackageFeatures = mergePackageFeatures { inherit packageId target; features = rootFeatures; };
         diffedDefaultPackageFeatures = diffDefaultPackageFeatures { inherit packageId;  features = rootFeatures; };
     };
 
@@ -510,14 +583,18 @@ rec {
    *
    * This is useful for verifying the feature resolution in crate2nix.
    */
-  diffDefaultPackageFeatures = {crateConfigs ? crates, packageId}:
+  diffDefaultPackageFeatures =
+    { crateConfigs ? crates
+    , packageId
+    , target
+    }:
     assert (builtins.isAttrs crateConfigs);
 
     let prefixValues = prefix: lib.mapAttrs (n: v: { "${prefix}" = v; });
         mergedFeatures =
           prefixValues
             "crate2nix"
-            (mergePackageFeatures {inherit crateConfigs packageId; features = ["default"]; });
+            (mergePackageFeatures {inherit crateConfigs packageId target; features = ["default"]; });
         configs = prefixValues "cargo" crateConfigs;
         combined = lib.foldAttrs (a: b: a // b) {} [ mergedFeatures configs ];
         onlyInCargo = builtins.attrNames (lib.filterAttrs (n: v: !(v ? "crate2nix" ) && (v ? "cargo")) combined);
@@ -538,12 +615,16 @@ rec {
      Returns multiple, potentially conflicting attribute sets for dependencies that are reachable
      by multiple paths in the dependency tree.
   */
+
   mergePackageFeatures = {
     crateConfigs ? crates,
     packageId,
+    rootPackageId,
     features ? rootFeatures,
     dependencyPath? [crates.${packageId}.crateName],
     featuresByPackageId? {},
+    target,
+    runTests,
     ...} @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
@@ -563,7 +644,10 @@ rec {
           assert (builtins.isAttrs cache);
           assert (builtins.isList dependencies);
 
-          let enabledDependencies = filterEnabledDependencies dependencies expandedFeatures;
+          let enabledDependencies = filterEnabledDependencies {
+                inherit dependencies target;
+                features = expandedFeatures;
+              };
               directDependencies = map depWithResolvedFeatures enabledDependencies;
               foldOverCache = op: lib.foldl op cache directDependencies;
           in foldOverCache
@@ -578,7 +662,7 @@ rec {
                   dependencyPath = dependencyPath ++ [path crateConfigs.${packageId}.crateName];
                   features = combinedFeatures;
                   featuresByPackageId = cache;
-                  inherit crateConfigs packageId;
+                  inherit crateConfigs packageId target runTests rootPackageId;
                  });
 
         cacheWithSelf =
@@ -589,21 +673,25 @@ rec {
             };
 
         cacheWithDependencies =
-            resolveDependencies cacheWithSelf "dep" (crateConfig.dependencies or []);
+            resolveDependencies cacheWithSelf "dep" (
+              crateConfig.dependencies or []
+              ++ lib.optionals (runTests && packageId == rootPackageId) (crateConfig.devDependencies or [])
+        );
         cacheWithAll =
             resolveDependencies cacheWithDependencies "build" (crateConfig.buildDependencies or []);
 
     in cacheWithAll;
 
   /* Returns the enabled dependencies given the enabled features. */
-  filterEnabledDependencies = dependencies: features:
+  filterEnabledDependencies = {dependencies, features, target}:
     assert (builtins.isList dependencies);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
 
     lib.filter
       (dep:
         let targetFunc = dep.target or (features: true);
-        in targetFunc features
+        in targetFunc { inherit features target; }
            && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 

--- a/sample_projects/with_problematic_crates/Cargo.nix
+++ b/sample_projects/with_problematic_crates/Cargo.nix
@@ -7154,15 +7154,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/sample_projects/with_problematic_crates/Cargo.nix
+++ b/sample_projects/with_problematic_crates/Cargo.nix
@@ -20,7 +20,7 @@ rec {
   #
 
   rootCrate = rec {
-    packageId = "with_problematic_crates 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/with_problematic_crates)";
+    packageId = "with_problematic_crates 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/with_problematic_crates)";
 
     # Use this attribute to refer to the derivation building your root crate package.
     # You can override the features with rootCrate.build.override { features = [ "default" "feature1" ... ]; }.
@@ -40,12 +40,12 @@ rec {
   # workspaceMembers."${crateName}".build.override { features = [ "default" "feature1" ... ]; }.
   workspaceMembers = {
     "with_problematic_crates" = rec {
-      packageId = "with_problematic_crates 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/with_problematic_crates)";
+      packageId = "with_problematic_crates 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/with_problematic_crates)";
       build = buildRustCrateWithFeatures {
-        packageId = "with_problematic_crates 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/with_problematic_crates)";
+        packageId = "with_problematic_crates 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/with_problematic_crates)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
@@ -68,6 +68,8 @@ rec {
   # * `dependencies`/`buildDependencies`: similar to the corresponding fields for buildRustCrate.
   #   but with additional information which is used during dependency/feature resolution.
   # * `resolvedDependencies`: the selected default features reported by cargo - only included for debugging.
+  # * `devDependencies` as of now not used by `buildRustCrate` but used to
+  #   inject test dependencies into the build
 
   crates = {
     "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
@@ -352,6 +354,17 @@ rec {
             usesDefaultFeatures = false;
           }
         ];
+        devDependencies = [
+          {
+            name = "actix-connect";
+            packageId = "actix-connect 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)";
+            features = [ "ssl" ];
+          }
+          {
+            name = "tokio-tcp";
+            packageId = "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
         features = {
           "brotli" = [ "brotli2" ];
           "fail" = [ "failure" ];
@@ -398,6 +411,12 @@ rec {
           {
             name = "string";
             packageId = "string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
+        devDependencies = [
+          {
+            name = "http";
+            packageId = "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)";
           }
         ];
         features = {
@@ -962,12 +981,12 @@ rec {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "consoleapi" "processenv" "minwinbase" "minwindef" "winbase" ];
           }
         ];
@@ -1055,6 +1074,17 @@ rec {
           {
             name = "tokio-timer";
             packageId = "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
+        devDependencies = [
+          {
+            name = "actix-http";
+            packageId = "actix-http 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)";
+            features = [ "ssl" ];
+          }
+          {
+            name = "rand";
+            packageId = "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)";
           }
         ];
         features = {
@@ -2195,7 +2225,7 @@ rec {
           {
             name = "miniz_oxide";
             packageId = "miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: ((target."arch" == "wasm32") && (!(target."os" == "emscripten")));
+            target = {target, features}: ((target."arch" == "wasm32") && (!(target."os" == "emscripten")));
           }
         ];
         features = {
@@ -2366,12 +2396,12 @@ rec {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "wasi";
             packageId = "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "wasi");
+            target = {target, features}: (target."os" == "wasi");
           }
         ];
         features = {
@@ -2510,12 +2540,12 @@ rec {
           {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."unix" || (target."os" == "redox"));
+            target = {target, features}: (target."unix" || (target."os" == "redox"));
           }
           {
             name = "winutil";
             packageId = "winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
         ];
         features = {
@@ -2867,7 +2897,7 @@ rec {
           {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
         ];
         features = {
@@ -2886,22 +2916,22 @@ rec {
           {
             name = "socket2";
             packageId = "socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
           {
             name = "widestring";
             packageId = "widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
           {
             name = "winreg";
             packageId = "winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
         ];
         features = {
@@ -3275,12 +3305,12 @@ rec {
           {
             name = "fuchsia-zircon";
             packageId = "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "fuchsia");
+            target = {target, features}: (target."os" == "fuchsia");
           }
           {
             name = "fuchsia-zircon-sys";
             packageId = "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "fuchsia");
+            target = {target, features}: (target."os" == "fuchsia");
           }
           {
             name = "iovec";
@@ -3289,12 +3319,12 @@ rec {
           {
             name = "kernel32-sys";
             packageId = "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
           {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "log";
@@ -3303,7 +3333,7 @@ rec {
           {
             name = "miow";
             packageId = "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
           {
             name = "net2";
@@ -3316,7 +3346,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
         ];
         features = {
@@ -3337,17 +3367,17 @@ rec {
           {
             name = "iovec";
             packageId = "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "mio";
             packageId = "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
         ];
         features = {
@@ -3401,12 +3431,12 @@ rec {
           {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: ((target."os" == "redox") || target."unix");
+            target = {target, features}: ((target."os" == "redox") || target."unix");
           }
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "handleapi" "winsock2" "ws2def" "ws2ipdef" "ws2tcpip" ];
           }
         ];
@@ -3460,7 +3490,7 @@ rec {
           {
             name = "cc";
             packageId = "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "dragonfly");
+            target = {target, features}: (target."os" == "dragonfly");
           }
         ];
         features = {
@@ -3526,7 +3556,7 @@ rec {
           {
             name = "hermit-abi";
             packageId = "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (((target."arch" == "x86_64") || (target."arch" == "aarch64")) && (target."os" == "hermit"));
+            target = {target, features}: (((target."arch" == "x86_64") || (target."arch" == "aarch64")) && (target."os" == "hermit"));
           }
           {
             name = "libc";
@@ -3625,17 +3655,17 @@ rec {
           {
             name = "cloudabi";
             packageId = "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "cloudabi");
+            target = {target, features}: (target."os" == "cloudabi");
           }
           {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "redox_syscall";
             packageId = "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "redox");
+            target = {target, features}: (target."os" == "redox");
           }
           {
             name = "smallvec";
@@ -3644,7 +3674,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "winnt" "ntstatus" "minwindef" "winerror" "winbase" "errhandlingapi" "handleapi" ];
           }
         ];
@@ -3675,17 +3705,17 @@ rec {
           {
             name = "cloudabi";
             packageId = "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "cloudabi");
+            target = {target, features}: (target."os" == "cloudabi");
           }
           {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "redox_syscall";
             packageId = "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "redox");
+            target = {target, features}: (target."os" == "redox");
           }
           {
             name = "smallvec";
@@ -3694,7 +3724,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "winnt" "ntstatus" "minwindef" "winerror" "winbase" "errhandlingapi" "handleapi" ];
           }
         ];
@@ -4106,7 +4136,7 @@ rec {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "rand_chacha";
@@ -4144,7 +4174,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "minwindef" "ntsecapi" "profileapi" "winnt" ];
           }
         ];
@@ -4187,13 +4217,13 @@ rec {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "rand_chacha";
             packageId = "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: (!(target."os" == "emscripten"));
+            target = {target, features}: (!(target."os" == "emscripten"));
           }
           {
             name = "rand_core";
@@ -4202,7 +4232,13 @@ rec {
           {
             name = "rand_hc";
             packageId = "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "emscripten");
+            target = {target, features}: (target."os" == "emscripten");
+          }
+        ];
+        devDependencies = [
+          {
+            name = "rand_hc";
+            packageId = "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)";
           }
         ];
         features = {
@@ -4407,7 +4443,7 @@ rec {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: ((target."os" == "macos") || (target."os" == "ios"));
+            target = {target, features}: ((target."os" == "macos") || (target."os" == "ios"));
           }
           {
             name = "rand_core";
@@ -4416,7 +4452,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "windows");
+            target = {target, features}: (target."os" == "windows");
             features = [ "profileapi" ];
           }
         ];
@@ -4438,17 +4474,17 @@ rec {
           {
             name = "cloudabi";
             packageId = "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "cloudabi");
+            target = {target, features}: (target."os" == "cloudabi");
           }
           {
             name = "fuchsia-cprng";
             packageId = "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "fuchsia");
+            target = {target, features}: (target."os" == "fuchsia");
           }
           {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "rand_core";
@@ -4458,12 +4494,12 @@ rec {
           {
             name = "rdrand";
             packageId = "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."env" == "sgx");
+            target = {target, features}: (target."env" == "sgx");
           }
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "minwindef" "ntsecapi" "winnt" ];
           }
         ];
@@ -4746,6 +4782,12 @@ rec {
             optional = true;
           }
         ];
+        devDependencies = [
+          {
+            name = "serde_derive";
+            packageId = "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
         features = {
           "default" = [ "std" ];
           "derive" = [ "serde_derive" ];
@@ -4867,6 +4909,13 @@ rec {
           {
             name = "opaque-debug";
             packageId = "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
+        devDependencies = [
+          {
+            name = "digest";
+            packageId = "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)";
+            features = [ "dev" ];
           }
         ];
         features = {
@@ -5023,22 +5072,22 @@ rec {
           {
             name = "cfg-if";
             packageId = "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."unix" || (target."os" == "redox"));
+            target = {target, features}: (target."unix" || (target."os" == "redox"));
           }
           {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."unix" || (target."os" == "redox"));
+            target = {target, features}: (target."unix" || (target."os" == "redox"));
           }
           {
             name = "redox_syscall";
             packageId = "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "redox");
+            target = {target, features}: (target."os" == "redox");
           }
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "handleapi" "ws2def" "ws2ipdef" "ws2tcpip" "minwindef" ];
           }
         ];
@@ -5115,6 +5164,12 @@ rec {
           }
         ];
         buildDependencies = [
+          {
+            name = "string_cache_codegen";
+            packageId = "string_cache_codegen 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
+        devDependencies = [
           {
             name = "string_cache_codegen";
             packageId = "string_cache_codegen 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)";
@@ -5383,7 +5438,7 @@ rec {
           {
             name = "wincolor";
             packageId = "wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
         ];
         features = {
@@ -5444,13 +5499,20 @@ rec {
           {
             name = "redox_syscall";
             packageId = "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "redox");
+            target = {target, features}: (target."os" == "redox");
           }
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "std" "minwinbase" "minwindef" "ntdef" "profileapi" "sysinfoapi" "timezoneapi" ];
+          }
+        ];
+        devDependencies = [
+          {
+            name = "winapi";
+            packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
+            features = [ "std" "processthreadsapi" "winbase" ];
           }
         ];
         features = {
@@ -5514,6 +5576,12 @@ rec {
             name = "tokio-timer";
             packageId = "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)";
             optional = true;
+          }
+        ];
+        devDependencies = [
+          {
+            name = "num_cpus";
+            packageId = "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)";
           }
         ];
         features = {
@@ -5755,6 +5823,12 @@ rec {
             packageId = "tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)";
           }
         ];
+        devDependencies = [
+          {
+            name = "num_cpus";
+            packageId = "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
         features = {
         };
       };
@@ -5775,7 +5849,7 @@ rec {
           {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "mio";
@@ -5784,12 +5858,12 @@ rec {
           {
             name = "mio-uds";
             packageId = "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "signal-hook";
             packageId = "signal-hook 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "tokio-executor";
@@ -5806,7 +5880,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "minwindef" "wincon" ];
           }
         ];
@@ -6012,7 +6086,7 @@ rec {
           {
             name = "spin";
             packageId = "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (!(builtins.elem "std" features));
+            target = {target, features}: (!(builtins.elem "std" features));
           }
           {
             name = "tracing-attributes";
@@ -6074,13 +6148,13 @@ rec {
           {
             name = "lazy_static";
             packageId = "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (!(builtins.elem "std" features));
+            target = {target, features}: (!(builtins.elem "std" features));
             features = [ "spin_no_std" ];
           }
           {
             name = "spin";
             packageId = "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (!(builtins.elem "std" features));
+            target = {target, features}: (!(builtins.elem "std" features));
           }
         ];
         features = {
@@ -6202,7 +6276,7 @@ rec {
           {
             name = "ipconfig";
             packageId = "ipconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
           {
             name = "lazy_static";
@@ -6632,12 +6706,12 @@ rec {
           {
             name = "winapi-i686-pc-windows-gnu";
             packageId = "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (stdenv.hostPlatform.config == "i686-pc-windows-gnu");
+            target = {target, features}: (stdenv.hostPlatform.config == "i686-pc-windows-gnu");
           }
           {
             name = "winapi-x86_64-pc-windows-gnu";
             packageId = "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (stdenv.hostPlatform.config == "x86_64-pc-windows-gnu");
+            target = {target, features}: (stdenv.hostPlatform.config == "x86_64-pc-windows-gnu");
           }
         ];
         features = {
@@ -6683,7 +6757,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "std" "consoleapi" "errhandlingapi" "fileapi" "minwindef" "processenv" "winbase" "wincon" "winerror" "winnt" ];
           }
         ];
@@ -6759,14 +6833,14 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "wow64apiset" "processthreadsapi" "winbase" ];
           }
         ];
         features = {
         };
       };
-    "with_problematic_crates 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_projects/with_problematic_crates)"
+    "with_problematic_crates 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_projects/with_problematic_crates)"
       = rec {
         crateName = "with_problematic_crates";
         version = "0.1.0";
@@ -6900,11 +6974,10 @@ rec {
 
   # Target (platform) data for conditional dependencies.
   # This corresponds roughly to what buildRustCrate is setting.
-  target = {
+  defaultTarget = {
       unix = true;
       windows = false;
       fuchsia = true;
-      # We don't support tests yet, so this is true for now.
       test = false;
 
       # This doesn't appear to be officially documented anywhere yet.
@@ -6962,66 +7035,138 @@ rec {
       baseName == "tests.nix"
     );
 
+  /* Returns a crate which depends on successful test execution of crate given as the second argument */
+  crateWithTest = crate: testCrate: testCrateFlags:
+    let
+      # override the `crate` so that it will build and execute tests instead of
+      # building the actual lib and bin targets We just have to pass `--test`
+      # to rustc and it will do the right thing.  We execute the tests and copy
+      # their log and the test executables to $out for later inspection.
+      test = let
+        drv = testCrate.override (_: {
+          buildTests = true;
+        });
+      in pkgs.runCommand "run-tests-${testCrate.name}" {
+        inherit testCrateFlags;
+      } ''
+        set -e
+        for file in ${drv}/tests/*; do
+          echo "Executing test $file" | tee -a $out
+          $file -- "$testCrateFlags" 2>&1 | tee -a $out
+        done
+      '';
+    in crate.overrideAttrs (old: {
+      checkPhase = ''
+        test -e ${test}
+      '';
+      passthru = (old.passthru or {}) // {
+        inherit test;
+      };
+    });
+
   /* A restricted overridable version of  buildRustCrateWithFeaturesImpl. */
-  buildRustCrateWithFeatures = {
-        packageId, 
-        features ? rootFeatures,
-        crateOverrides ? defaultCrateOverrides, 
-        buildRustCrateFunc ? buildRustCrate
-      }:
+  buildRustCrateWithFeatures =
+    { packageId
+    , features ? rootFeatures
+    , crateOverrides ? defaultCrateOverrides
+    , buildRustCrateFunc ? buildRustCrate
+    , runTests ? false
+    , testCrateFlags ? []
+    }:
     lib.makeOverridable
-      ({features, crateOverrides}: 
-        let builtRustCrates = builtRustCratesWithFeatures {
-          inherit packageId features crateOverrides  buildRustCrateFunc;
-        };
-        in builtRustCrates.${packageId})
-      { inherit features crateOverrides; };
+      ({features, crateOverrides, runTests, testCrateFlags}:
+        let
+          builtRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = false;
+          };
+          builtTestRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = true;
+          };
+          drv = builtRustCrates.${packageId};
+          testDrv = builtTestRustCrates.${packageId};
+        in if runTests then crateWithTest drv testDrv testCrateFlags else drv)
+      { inherit features crateOverrides runTests testCrateFlags; };
 
   /* Returns a buildRustCrate derivation for the given packageId and features. */
-  builtRustCratesWithFeatures = { 
-        crateConfigs? crates, 
-        packageId,
-        features,
-        crateOverrides, 
-        buildRustCrateFunc
-      } @ args:
+  builtRustCratesWithFeatures =
+    { packageId
+    , features
+    , crateConfigs ? crates
+    , crateOverrides
+    , buildRustCrateFunc
+    , runTests
+    , target ? defaultTarget
+    } @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
+    assert (builtins.isBool runTests);
 
-    let mergedFeatures = mergePackageFeatures args;
+    let rootPackageId = packageId;
+        mergedFeatures = mergePackageFeatures (args // {
+          inherit rootPackageId;
+          target = target // { test = runTests; };
+        });
+
+        buildByPackageId = packageId: buildByPackageIdImpl packageId;
+
         # Memoize built packages so that reappearing packages are only built once.
         builtByPackageId =
           lib.mapAttrs (packageId: value: buildByPackageId packageId) crateConfigs;
-        buildByPackageId = packageId:
-          let features = mergedFeatures."${packageId}" or [];
-              crateConfig = lib.filterAttrs (n: v: n != "resolvedDefaultFeatures") crateConfigs."${packageId}";
+
+        buildByPackageIdImpl = packageId:
+          let
+              features = mergedFeatures."${packageId}" or [];
+              crateConfig' = crateConfigs."${packageId}";
+              crateConfig = builtins.removeAttrs crateConfig' ["resolvedDefaultFeatures" "devDependencies"];
+              devDependencies = lib.optionals (runTests && packageId == rootPackageId) (crateConfig'.devDependencies or []);
               dependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.dependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies =
+                   (crateConfig.dependencies or [])
+                    ++ devDependencies;
+                };
               buildDependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.buildDependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies = crateConfig.buildDependencies or [];
+                };
+
               dependenciesWithRenames =
-                lib.filter (d: d ? "rename")
-                  (crateConfig.buildDependencies or [] ++ crateConfig.dependencies or []);
+                lib.filter (d: d ? "rename") (
+                  (crateConfig.buildDependencies or [])
+                  ++ (crateConfig.dependencies or [])
+                  ++ devDependencies);
+
               crateRenames =
                 builtins.listToAttrs (map (d: { name = d.name; value = d.rename; }) dependenciesWithRenames);
-          in buildRustCrateFunc (crateConfig // { 
+          in buildRustCrateFunc (crateConfig // {
             src = crateConfig.src or (pkgs.fetchurl {
               name = "${crateConfig.crateName}-${crateConfig.version}.tar.gz";
               url = "https://crates.io/api/v1/crates/${crateConfig.crateName}/${crateConfig.version}/download";
               sha256 = crateConfig.sha256;
             });
-            inherit features dependencies buildDependencies crateRenames; 
+            inherit features dependencies buildDependencies crateRenames;
           });
     in builtByPackageId;
 
   /* Returns the actual derivations for the given dependencies. */
-  dependencyDerivations = builtByPackageId: features: dependencies:
+  dependencyDerivations =
+    { builtByPackageId
+    , features
+    , dependencies
+    , target
+    }:
     assert (builtins.isAttrs builtByPackageId);
     assert (builtins.isList features);
     assert (builtins.isList dependencies);
+    assert (builtins.isAttrs target);
 
-    let enabledDependencies = filterEnabledDependencies dependencies features;
+    let enabledDependencies = filterEnabledDependencies { inherit dependencies features target; };
         depDerivation = dependency: builtByPackageId.${dependency.packageId};
     in map depDerivation enabledDependencies;
 
@@ -7034,7 +7179,7 @@ rec {
           then "function"
           else val;
 
-  debugCrate = {packageId}:
+  debugCrate = {packageId, target}:
     assert (builtins.isString packageId);
 
     rec {
@@ -7052,7 +7197,7 @@ rec {
             };
             inherit packageId;
         });
-        mergedPackageFeatures = mergePackageFeatures { inherit packageId; features = rootFeatures; };
+        mergedPackageFeatures = mergePackageFeatures { inherit packageId target; features = rootFeatures; };
         diffedDefaultPackageFeatures = diffDefaultPackageFeatures { inherit packageId;  features = rootFeatures; };
     };
 
@@ -7060,14 +7205,18 @@ rec {
    *
    * This is useful for verifying the feature resolution in crate2nix.
    */
-  diffDefaultPackageFeatures = {crateConfigs ? crates, packageId}:
+  diffDefaultPackageFeatures =
+    { crateConfigs ? crates
+    , packageId
+    , target
+    }:
     assert (builtins.isAttrs crateConfigs);
 
     let prefixValues = prefix: lib.mapAttrs (n: v: { "${prefix}" = v; });
         mergedFeatures =
           prefixValues
             "crate2nix"
-            (mergePackageFeatures {inherit crateConfigs packageId; features = ["default"]; });
+            (mergePackageFeatures {inherit crateConfigs packageId target; features = ["default"]; });
         configs = prefixValues "cargo" crateConfigs;
         combined = lib.foldAttrs (a: b: a // b) {} [ mergedFeatures configs ];
         onlyInCargo = builtins.attrNames (lib.filterAttrs (n: v: !(v ? "crate2nix" ) && (v ? "cargo")) combined);
@@ -7088,12 +7237,16 @@ rec {
      Returns multiple, potentially conflicting attribute sets for dependencies that are reachable
      by multiple paths in the dependency tree.
   */
+
   mergePackageFeatures = {
     crateConfigs ? crates,
     packageId,
+    rootPackageId,
     features ? rootFeatures,
     dependencyPath? [crates.${packageId}.crateName],
     featuresByPackageId? {},
+    target,
+    runTests,
     ...} @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
@@ -7113,7 +7266,10 @@ rec {
           assert (builtins.isAttrs cache);
           assert (builtins.isList dependencies);
 
-          let enabledDependencies = filterEnabledDependencies dependencies expandedFeatures;
+          let enabledDependencies = filterEnabledDependencies {
+                inherit dependencies target;
+                features = expandedFeatures;
+              };
               directDependencies = map depWithResolvedFeatures enabledDependencies;
               foldOverCache = op: lib.foldl op cache directDependencies;
           in foldOverCache
@@ -7128,7 +7284,7 @@ rec {
                   dependencyPath = dependencyPath ++ [path crateConfigs.${packageId}.crateName];
                   features = combinedFeatures;
                   featuresByPackageId = cache;
-                  inherit crateConfigs packageId;
+                  inherit crateConfigs packageId target runTests rootPackageId;
                  });
 
         cacheWithSelf =
@@ -7139,21 +7295,25 @@ rec {
             };
 
         cacheWithDependencies =
-            resolveDependencies cacheWithSelf "dep" (crateConfig.dependencies or []);
+            resolveDependencies cacheWithSelf "dep" (
+              crateConfig.dependencies or []
+              ++ lib.optionals (runTests && packageId == rootPackageId) (crateConfig.devDependencies or [])
+        );
         cacheWithAll =
             resolveDependencies cacheWithDependencies "build" (crateConfig.buildDependencies or []);
 
     in cacheWithAll;
 
   /* Returns the enabled dependencies given the enabled features. */
-  filterEnabledDependencies = dependencies: features:
+  filterEnabledDependencies = {dependencies, features, target}:
     assert (builtins.isList dependencies);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
 
     lib.filter
       (dep:
         let targetFunc = dep.target or (features: true);
-        in targetFunc features
+        in targetFunc { inherit features target; }
            && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 

--- a/sample_workspace/Cargo.nix
+++ b/sample_workspace/Cargo.nix
@@ -25,67 +25,67 @@ rec {
   # workspaceMembers."${crateName}".build.override { features = [ "default" "feature1" ... ]; }.
   workspaceMembers = {
     "bin_with_default_features" = rec {
-      packageId = "bin_with_default_features 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/bin_with_default_features)";
+      packageId = "bin_with_default_features 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/bin_with_default_features)";
       build = buildRustCrateWithFeatures {
-        packageId = "bin_with_default_features 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/bin_with_default_features)";
+        packageId = "bin_with_default_features 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/bin_with_default_features)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
     };
     "hello_world_bin" = rec {
-      packageId = "hello_world_bin 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/bin)";
+      packageId = "hello_world_bin 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/bin)";
       build = buildRustCrateWithFeatures {
-        packageId = "hello_world_bin 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/bin)";
+        packageId = "hello_world_bin 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/bin)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
     };
     "hello_world_lib" = rec {
-      packageId = "hello_world_lib 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/lib)";
+      packageId = "hello_world_lib 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/lib)";
       build = buildRustCrateWithFeatures {
-        packageId = "hello_world_lib 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/lib)";
+        packageId = "hello_world_lib 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/lib)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
     };
     "hello_world_lib_and_bin" = rec {
-      packageId = "hello_world_lib_and_bin 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/lib_and_bin)";
+      packageId = "hello_world_lib_and_bin 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/lib_and_bin)";
       build = buildRustCrateWithFeatures {
-        packageId = "hello_world_lib_and_bin 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/lib_and_bin)";
+        packageId = "hello_world_lib_and_bin 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/lib_and_bin)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
     };
     "hello_world_with_dep" = rec {
-      packageId = "hello_world_with_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/bin_with_lib_dep)";
+      packageId = "hello_world_with_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/bin_with_lib_dep)";
       build = buildRustCrateWithFeatures {
-        packageId = "hello_world_with_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/bin_with_lib_dep)";
+        packageId = "hello_world_with_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/bin_with_lib_dep)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
     };
     "with_tera" = rec {
-      packageId = "with_tera 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/with_tera)";
+      packageId = "with_tera 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/with_tera)";
       build = buildRustCrateWithFeatures {
-        packageId = "with_tera 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/with_tera)";
+        packageId = "with_tera 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/with_tera)";
         features = rootFeatures;
       };
-      
+
       # Debug support which might change between releases.
       # File a bug if you depend on any for non-debug work!
       debug = debugCrate { inherit packageId; };
@@ -108,6 +108,8 @@ rec {
   # * `dependencies`/`buildDependencies`: similar to the corresponding fields for buildRustCrate.
   #   but with additional information which is used during dependency/feature resolution.
   # * `resolvedDependencies`: the selected default features reported by cargo - only included for debugging.
+  # * `devDependencies` as of now not used by `buildRustCrate` but used to
+  #   inject test dependencies into the build
 
   crates = {
     "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)"
@@ -145,7 +147,7 @@ rec {
         features = {
         };
       };
-    "bin_with_default_features 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/bin_with_default_features)"
+    "bin_with_default_features 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/bin_with_default_features)"
       = rec {
         crateName = "bin_with_default_features";
         version = "0.1.0";
@@ -160,7 +162,7 @@ rec {
         dependencies = [
           {
             name = "hello_world_lib";
-            packageId = "hello_world_lib 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/lib)";
+            packageId = "hello_world_lib 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/lib)";
             optional = true;
           }
         ];
@@ -506,12 +508,12 @@ rec {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "wasi";
             packageId = "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "wasi");
+            target = {target, features}: (target."os" == "wasi");
           }
         ];
         features = {
@@ -578,7 +580,7 @@ rec {
         features = {
         };
       };
-    "hello_world_bin 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/bin)"
+    "hello_world_bin 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/bin)"
       = rec {
         crateName = "hello_world_bin";
         version = "0.1.0";
@@ -593,7 +595,7 @@ rec {
         features = {
         };
       };
-    "hello_world_lib 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/lib)"
+    "hello_world_lib 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/lib)"
       = rec {
         crateName = "hello_world_lib";
         version = "0.1.0";
@@ -605,7 +607,7 @@ rec {
         features = {
         };
       };
-    "hello_world_lib_and_bin 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/lib_and_bin)"
+    "hello_world_lib_and_bin 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/lib_and_bin)"
       = rec {
         crateName = "hello_world_lib_and_bin";
         version = "0.1.0";
@@ -620,7 +622,7 @@ rec {
         features = {
         };
       };
-    "hello_world_with_dep 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/bin_with_lib_dep)"
+    "hello_world_with_dep 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/bin_with_lib_dep)"
       = rec {
         crateName = "hello_world_with_dep";
         version = "0.1.0";
@@ -635,7 +637,13 @@ rec {
         dependencies = [
           {
             name = "hello_world_lib";
-            packageId = "hello_world_lib 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/lib)";
+            packageId = "hello_world_lib 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/lib)";
+          }
+        ];
+        devDependencies = [
+          {
+            name = "hello_world_lib";
+            packageId = "hello_world_lib 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/lib)";
           }
         ];
         features = {
@@ -702,7 +710,7 @@ rec {
           {
             name = "winapi-util";
             packageId = "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
         ];
         features = {
@@ -1070,13 +1078,13 @@ rec {
             name = "libc";
             packageId = "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: target."unix";
+            target = {target, features}: target."unix";
           }
           {
             name = "rand_chacha";
             packageId = "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
-            target = features: (!(target."os" == "emscripten"));
+            target = {target, features}: (!(target."os" == "emscripten"));
           }
           {
             name = "rand_core";
@@ -1085,7 +1093,13 @@ rec {
           {
             name = "rand_hc";
             packageId = "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "emscripten");
+            target = {target, features}: (target."os" == "emscripten");
+          }
+        ];
+        devDependencies = [
+          {
+            name = "rand_hc";
+            packageId = "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)";
           }
         ];
         features = {
@@ -1273,7 +1287,7 @@ rec {
           {
             name = "winapi-util";
             packageId = "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
         ];
         features = {
@@ -1350,6 +1364,13 @@ rec {
           {
             name = "opaque-debug";
             packageId = "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)";
+          }
+        ];
+        devDependencies = [
+          {
+            name = "digest";
+            packageId = "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)";
+            features = [ "dev" ];
           }
         ];
         features = {
@@ -1525,13 +1546,20 @@ rec {
           {
             name = "redox_syscall";
             packageId = "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (target."os" == "redox");
+            target = {target, features}: (target."os" == "redox");
           }
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "std" "minwinbase" "minwindef" "ntdef" "profileapi" "sysinfoapi" "timezoneapi" ];
+          }
+        ];
+        devDependencies = [
+          {
+            name = "winapi";
+            packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
+            features = [ "std" "processthreadsapi" "winbase" ];
           }
         ];
         features = {
@@ -1703,13 +1731,13 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "std" "winnt" ];
           }
           {
             name = "winapi-util";
             packageId = "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
           }
         ];
         features = {
@@ -1743,12 +1771,12 @@ rec {
           {
             name = "winapi-i686-pc-windows-gnu";
             packageId = "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (stdenv.hostPlatform.config == "i686-pc-windows-gnu");
+            target = {target, features}: (stdenv.hostPlatform.config == "i686-pc-windows-gnu");
           }
           {
             name = "winapi-x86_64-pc-windows-gnu";
             packageId = "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: (stdenv.hostPlatform.config == "x86_64-pc-windows-gnu");
+            target = {target, features}: (stdenv.hostPlatform.config == "x86_64-pc-windows-gnu");
           }
         ];
         features = {
@@ -1781,7 +1809,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = features: target."windows";
+            target = {target, features}: target."windows";
             features = [ "std" "consoleapi" "errhandlingapi" "fileapi" "minwindef" "processenv" "winbase" "wincon" "winerror" "winnt" ];
           }
         ];
@@ -1800,7 +1828,7 @@ rec {
         features = {
         };
       };
-    "with_tera 0.1.0 (path+file:///home/peter/projects/crate2nix/sample_workspace/with_tera)"
+    "with_tera 0.1.0 (path+file:///home/andi/dev/tweag/sc/crate2nix/sample_workspace/with_tera)"
       = rec {
         crateName = "with_tera";
         version = "0.1.0";
@@ -1829,11 +1857,10 @@ rec {
 
   # Target (platform) data for conditional dependencies.
   # This corresponds roughly to what buildRustCrate is setting.
-  target = {
+  defaultTarget = {
       unix = true;
       windows = false;
       fuchsia = true;
-      # We don't support tests yet, so this is true for now.
       test = false;
 
       # This doesn't appear to be officially documented anywhere yet.
@@ -1891,66 +1918,138 @@ rec {
       baseName == "tests.nix"
     );
 
+  /* Returns a crate which depends on successful test execution of crate given as the second argument */
+  crateWithTest = crate: testCrate: testCrateFlags:
+    let
+      # override the `crate` so that it will build and execute tests instead of
+      # building the actual lib and bin targets We just have to pass `--test`
+      # to rustc and it will do the right thing.  We execute the tests and copy
+      # their log and the test executables to $out for later inspection.
+      test = let
+        drv = testCrate.override (_: {
+          buildTests = true;
+        });
+      in pkgs.runCommand "run-tests-${testCrate.name}" {
+        inherit testCrateFlags;
+      } ''
+        set -e
+        for file in ${drv}/tests/*; do
+          echo "Executing test $file" | tee -a $out
+          $file -- "$testCrateFlags" 2>&1 | tee -a $out
+        done
+      '';
+    in crate.overrideAttrs (old: {
+      checkPhase = ''
+        test -e ${test}
+      '';
+      passthru = (old.passthru or {}) // {
+        inherit test;
+      };
+    });
+
   /* A restricted overridable version of  buildRustCrateWithFeaturesImpl. */
-  buildRustCrateWithFeatures = {
-        packageId, 
-        features ? rootFeatures,
-        crateOverrides ? defaultCrateOverrides, 
-        buildRustCrateFunc ? buildRustCrate
-      }:
+  buildRustCrateWithFeatures =
+    { packageId
+    , features ? rootFeatures
+    , crateOverrides ? defaultCrateOverrides
+    , buildRustCrateFunc ? buildRustCrate
+    , runTests ? false
+    , testCrateFlags ? []
+    }:
     lib.makeOverridable
-      ({features, crateOverrides}: 
-        let builtRustCrates = builtRustCratesWithFeatures {
-          inherit packageId features crateOverrides  buildRustCrateFunc;
-        };
-        in builtRustCrates.${packageId})
-      { inherit features crateOverrides; };
+      ({features, crateOverrides, runTests, testCrateFlags}:
+        let
+          builtRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = false;
+          };
+          builtTestRustCrates = builtRustCratesWithFeatures {
+            inherit packageId features crateOverrides buildRustCrateFunc;
+            runTests = true;
+          };
+          drv = builtRustCrates.${packageId};
+          testDrv = builtTestRustCrates.${packageId};
+        in if runTests then crateWithTest drv testDrv testCrateFlags else drv)
+      { inherit features crateOverrides runTests testCrateFlags; };
 
   /* Returns a buildRustCrate derivation for the given packageId and features. */
-  builtRustCratesWithFeatures = { 
-        crateConfigs? crates, 
-        packageId,
-        features,
-        crateOverrides, 
-        buildRustCrateFunc
-      } @ args:
+  builtRustCratesWithFeatures =
+    { packageId
+    , features
+    , crateConfigs ? crates
+    , crateOverrides
+    , buildRustCrateFunc
+    , runTests
+    , target ? defaultTarget
+    } @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
+    assert (builtins.isBool runTests);
 
-    let mergedFeatures = mergePackageFeatures args;
+    let rootPackageId = packageId;
+        mergedFeatures = mergePackageFeatures (args // {
+          inherit rootPackageId;
+          target = target // { test = runTests; };
+        });
+
+        buildByPackageId = packageId: buildByPackageIdImpl packageId;
+
         # Memoize built packages so that reappearing packages are only built once.
         builtByPackageId =
           lib.mapAttrs (packageId: value: buildByPackageId packageId) crateConfigs;
-        buildByPackageId = packageId:
-          let features = mergedFeatures."${packageId}" or [];
-              crateConfig = lib.filterAttrs (n: v: n != "resolvedDefaultFeatures") crateConfigs."${packageId}";
+
+        buildByPackageIdImpl = packageId:
+          let
+              features = mergedFeatures."${packageId}" or [];
+              crateConfig' = crateConfigs."${packageId}";
+              crateConfig = builtins.removeAttrs crateConfig' ["resolvedDefaultFeatures" "devDependencies"];
+              devDependencies = lib.optionals (runTests && packageId == rootPackageId) (crateConfig'.devDependencies or []);
               dependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.dependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies =
+                   (crateConfig.dependencies or [])
+                    ++ devDependencies;
+                };
               buildDependencies =
-                dependencyDerivations builtByPackageId features (crateConfig.buildDependencies or []);
+                dependencyDerivations {
+                  inherit builtByPackageId features target;
+                  dependencies = crateConfig.buildDependencies or [];
+                };
+
               dependenciesWithRenames =
-                lib.filter (d: d ? "rename")
-                  (crateConfig.buildDependencies or [] ++ crateConfig.dependencies or []);
+                lib.filter (d: d ? "rename") (
+                  (crateConfig.buildDependencies or [])
+                  ++ (crateConfig.dependencies or [])
+                  ++ devDependencies);
+
               crateRenames =
                 builtins.listToAttrs (map (d: { name = d.name; value = d.rename; }) dependenciesWithRenames);
-          in buildRustCrateFunc (crateConfig // { 
+          in buildRustCrateFunc (crateConfig // {
             src = crateConfig.src or (pkgs.fetchurl {
               name = "${crateConfig.crateName}-${crateConfig.version}.tar.gz";
               url = "https://crates.io/api/v1/crates/${crateConfig.crateName}/${crateConfig.version}/download";
               sha256 = crateConfig.sha256;
             });
-            inherit features dependencies buildDependencies crateRenames; 
+            inherit features dependencies buildDependencies crateRenames;
           });
     in builtByPackageId;
 
   /* Returns the actual derivations for the given dependencies. */
-  dependencyDerivations = builtByPackageId: features: dependencies:
+  dependencyDerivations =
+    { builtByPackageId
+    , features
+    , dependencies
+    , target
+    }:
     assert (builtins.isAttrs builtByPackageId);
     assert (builtins.isList features);
     assert (builtins.isList dependencies);
+    assert (builtins.isAttrs target);
 
-    let enabledDependencies = filterEnabledDependencies dependencies features;
+    let enabledDependencies = filterEnabledDependencies { inherit dependencies features target; };
         depDerivation = dependency: builtByPackageId.${dependency.packageId};
     in map depDerivation enabledDependencies;
 
@@ -1963,7 +2062,7 @@ rec {
           then "function"
           else val;
 
-  debugCrate = {packageId}:
+  debugCrate = {packageId, target}:
     assert (builtins.isString packageId);
 
     rec {
@@ -1981,7 +2080,7 @@ rec {
             };
             inherit packageId;
         });
-        mergedPackageFeatures = mergePackageFeatures { inherit packageId; features = rootFeatures; };
+        mergedPackageFeatures = mergePackageFeatures { inherit packageId target; features = rootFeatures; };
         diffedDefaultPackageFeatures = diffDefaultPackageFeatures { inherit packageId;  features = rootFeatures; };
     };
 
@@ -1989,14 +2088,18 @@ rec {
    *
    * This is useful for verifying the feature resolution in crate2nix.
    */
-  diffDefaultPackageFeatures = {crateConfigs ? crates, packageId}:
+  diffDefaultPackageFeatures =
+    { crateConfigs ? crates
+    , packageId
+    , target
+    }:
     assert (builtins.isAttrs crateConfigs);
 
     let prefixValues = prefix: lib.mapAttrs (n: v: { "${prefix}" = v; });
         mergedFeatures =
           prefixValues
             "crate2nix"
-            (mergePackageFeatures {inherit crateConfigs packageId; features = ["default"]; });
+            (mergePackageFeatures {inherit crateConfigs packageId target; features = ["default"]; });
         configs = prefixValues "cargo" crateConfigs;
         combined = lib.foldAttrs (a: b: a // b) {} [ mergedFeatures configs ];
         onlyInCargo = builtins.attrNames (lib.filterAttrs (n: v: !(v ? "crate2nix" ) && (v ? "cargo")) combined);
@@ -2017,12 +2120,16 @@ rec {
      Returns multiple, potentially conflicting attribute sets for dependencies that are reachable
      by multiple paths in the dependency tree.
   */
+
   mergePackageFeatures = {
     crateConfigs ? crates,
     packageId,
+    rootPackageId,
     features ? rootFeatures,
     dependencyPath? [crates.${packageId}.crateName],
     featuresByPackageId? {},
+    target,
+    runTests,
     ...} @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
@@ -2042,7 +2149,10 @@ rec {
           assert (builtins.isAttrs cache);
           assert (builtins.isList dependencies);
 
-          let enabledDependencies = filterEnabledDependencies dependencies expandedFeatures;
+          let enabledDependencies = filterEnabledDependencies {
+                inherit dependencies target;
+                features = expandedFeatures;
+              };
               directDependencies = map depWithResolvedFeatures enabledDependencies;
               foldOverCache = op: lib.foldl op cache directDependencies;
           in foldOverCache
@@ -2057,7 +2167,7 @@ rec {
                   dependencyPath = dependencyPath ++ [path crateConfigs.${packageId}.crateName];
                   features = combinedFeatures;
                   featuresByPackageId = cache;
-                  inherit crateConfigs packageId;
+                  inherit crateConfigs packageId target runTests rootPackageId;
                  });
 
         cacheWithSelf =
@@ -2068,21 +2178,25 @@ rec {
             };
 
         cacheWithDependencies =
-            resolveDependencies cacheWithSelf "dep" (crateConfig.dependencies or []);
+            resolveDependencies cacheWithSelf "dep" (
+              crateConfig.dependencies or []
+              ++ lib.optionals (runTests && packageId == rootPackageId) (crateConfig.devDependencies or [])
+        );
         cacheWithAll =
             resolveDependencies cacheWithDependencies "build" (crateConfig.buildDependencies or []);
 
     in cacheWithAll;
 
   /* Returns the enabled dependencies given the enabled features. */
-  filterEnabledDependencies = dependencies: features:
+  filterEnabledDependencies = {dependencies, features, target}:
     assert (builtins.isList dependencies);
     assert (builtins.isList features);
+    assert (builtins.isAttrs target);
 
     lib.filter
       (dep:
         let targetFunc = dep.target or (features: true);
-        in targetFunc features
+        in targetFunc { inherit features target; }
            && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 

--- a/sample_workspace/Cargo.nix
+++ b/sample_workspace/Cargo.nix
@@ -2083,15 +2083,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/tests.nix
+++ b/tests.nix
@@ -51,7 +51,7 @@ let crate2nix = pkgs.callPackage ./default.nix {};
               }
 
               ${lib.optionalString (lib.length expectedTestOutputs > 0) ''
-                cp ${derivation.test}/tests.log $out/tests.log
+                cp ${derivation.test} $out/tests.log
               ''}
               ${lib.concatMapStringsSep "\n" (output: ''
                 grep '${output}' $out/tests.log || {
@@ -133,7 +133,7 @@ let crate2nix = pkgs.callPackage ./default.nix {};
             cargoToml = "Cargo.toml";
             expectedOutput = "Hello, cfg-test!";
             expectedTestOutputs = [
-              "test cfg_test ... ok"
+              "test echo_foo_test ... ok"
               "test lib_test ... ok"
             ];
             customBuild = "sample_projects/cfg-test/test.nix";

--- a/tests.nix
+++ b/tests.nix
@@ -98,12 +98,22 @@ let crate2nix = pkgs.callPackage ./default.nix {};
          }
 
          {
-             name = "sample_project_cfg_test";
-             src = ./sample_projects/cfg-test;
-             cargoToml = "Cargo.toml";
-             expectedOutput = "Hello, cfg-test!";
+            name = "sample_project_cfg_test";
+            src = ./sample_projects/cfg-test;
+            cargoToml = "Cargo.toml";
+            expectedOutput = "Hello, cfg-test!";
+            pregeneratedBuild = "sample_projects/cfg-test/Cargo.nix";
+          }
+
+         {
+            name = "sample_project_cfg_test-with-tests";
+            src = ./sample_projects/cfg-test;
+            cargoToml = "Cargo.toml";
+            expectedOutput = "Hello, cfg-test!";
+            customBuild = "sample_projects/cfg-test/test.nix";
             pregeneratedBuild = "sample_projects/cfg-test/Cargo.nix";
          }
+
 
          {
             name = "sample_workspace";


### PR DESCRIPTION
This is a first step in starting to support running tests of crates in the current workspace.

As part of this I had to start refactoring `target` as that was being passed around as global state since it is required to override `target.test` in order to get features for test builds.

While doing that I decided to refactor some function calls from "normal" function arguments to attribute sets as arguments. The pattern of what was being passed on and required became a bit repetitive so it seemed like a good idea.

The idea is to pass `doTest = true` (e.g. using `.override`) to the build to additionally calculate the test features and dependencies. The build of that crate will then be passed to `buildRustCrate` (from nixpkgs) where it will be used to build & execute the tests in that crate. My current idea is to have those tests "build" as a dedicated derivation that will be required for the actual crate to succeed.

While this doesn't fully close that chapter yet it is a first step and some basic implementation to discuss how we want this to evolve. I'll  draft a PR to nixpkgs next that adds support for testing crates.