### PR TITLE
Enable optional crates when they are renamed and listed as feature

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -3537,15 +3537,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -261,15 +261,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -369,15 +369,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1606,15 +1606,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/sample_projects/bin_with_lib_git_dep/Cargo.nix
+++ b/sample_projects/bin_with_lib_git_dep/Cargo.nix
@@ -369,15 +369,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/sample_projects/bin_with_rerenamed_lib_dep/Cargo.lock
+++ b/sample_projects/bin_with_rerenamed_lib_dep/Cargo.lock
@@ -5,9 +5,14 @@ name = "bin_with_rerenamed_lib_dep"
 version = "0.1.0"
 dependencies = [
  "hello_world_lib 0.1.0",
+ "hello_world_lib_and_bin 0.1.0",
 ]
 
 [[package]]
 name = "hello_world_lib"
+version = "0.1.0"
+
+[[package]]
+name = "hello_world_lib_and_bin"
 version = "0.1.0"
 

--- a/sample_projects/bin_with_rerenamed_lib_dep/Cargo.toml
+++ b/sample_projects/bin_with_rerenamed_lib_dep/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2018"
 
 [dependencies]
 "new_name_hello_world_lib" = { package = "hello_world_lib", path = "../lib"}
+"feature_hello_world_lib_and_bin" = { package = "hello_world_lib_and_bin", path = "../lib_and_bin", optional = true}
+
+[features]
+default = [ "enable_renamed_crate" ]
+enable_renamed_crate = [ "feature_hello_world_lib_and_bin" ]

--- a/sample_projects/cfg-test/Cargo.nix
+++ b/sample_projects/cfg-test/Cargo.nix
@@ -608,15 +608,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/sample_projects/numtest/Cargo.nix
+++ b/sample_projects/numtest/Cargo.nix
@@ -604,15 +604,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/sample_projects/with_problematic_crates/Cargo.nix
+++ b/sample_projects/with_problematic_crates/Cargo.nix
@@ -7154,15 +7154,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 

--- a/sample_workspace/Cargo.nix
+++ b/sample_workspace/Cargo.nix
@@ -2083,15 +2083,15 @@ rec {
       (dep:
         let targetFunc = dep.target or (features: true);
         in targetFunc features
-           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep.name) features))
+           && (!(dep.optional or false) || builtins.any (doesFeatureEnableDependency dep) features))
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = depName: feature:
-    let prefix = "${depName}/";
+  doesFeatureEnableDependency = { name, rename ? null, ...}: feature:
+    let prefix = "${name}/";
         len = builtins.stringLength prefix;
         startsWithPrefix = builtins.substring 0 len feature == prefix;
-    in feature == depName || startsWithPrefix;
+    in feature == name || (rename != null && rename == feature) || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the rules in featureMap.
 


### PR DESCRIPTION
When a crate is renamed and optional it can be pulled in via the "new" name in the feature list and not (just?) the actual name.

 This is what I ran into with #62 .

I added a test case that roughly resembles the same issue but requires less external code.