### PR TITLE
Sketch out an alternative parallel prefetch algo

### DIFF
--- a/crate2nix/src/lib.rs
+++ b/crate2nix/src/lib.rs
@@ -155,7 +155,8 @@ fn prefetch_and_fill_crates_sha256(
         *hash = nix_base32::to_nix_base32(&bytes);
     }
 
-    let prefetched = prefetch::prefetch(config, &from_lock_file, &default_nix.crates)
+    let prefetched = prefetch::Prefetcher::new(config, &from_lock_file, &default_nix.crates)
+        .prefetch()
         .map_err(|e| format_err!("while prefetching crates for calculating sha256: {}", e))?;
 
     for package in default_nix.crates.iter_mut() {

--- a/crate2nix/src/lib.rs
+++ b/crate2nix/src/lib.rs
@@ -230,5 +230,5 @@ pub struct GenerateConfig {
     pub crate_hashes_json: PathBuf,
     pub nixpkgs_path: String,
     pub other_metadata_options: Vec<String>,
-    pub jobs: usize,
+    pub prefetch_parallelism: usize,
 }

--- a/crate2nix/src/lib.rs
+++ b/crate2nix/src/lib.rs
@@ -229,4 +229,5 @@ pub struct GenerateConfig {
     pub crate_hashes_json: PathBuf,
     pub nixpkgs_path: String,
     pub other_metadata_options: Vec<String>,
+    pub jobs: usize,
 }

--- a/crate2nix/src/main.rs
+++ b/crate2nix/src/main.rs
@@ -79,12 +79,12 @@ pub enum Opt {
         crate_hashes: Option<PathBuf>,
 
         #[structopt(
-            short = "j",
-            long = "max-jobs",
+            short = "p",
+            long = "prefetch-parallelism",
             default_value = "4",
-            help = "maximum concurrent fetch jobs"
+            help = "maximum concurrent prefetch jobs"
         )]
-        jobs: usize,
+        prefetch_parallelism: usize,
     },
 
     #[structopt(
@@ -123,7 +123,7 @@ fn main() -> CliResult {
             no_default_features,
             features,
             no_cargo_lock_checksums,
-            jobs,
+            prefetch_parallelism,
         } => {
             let crate_hashes_json = crate_hashes.unwrap_or_else(|| {
                 cargo_toml
@@ -164,7 +164,7 @@ fn main() -> CliResult {
                 crate_hashes_json,
                 other_metadata_options,
                 use_cargo_lock_checksums: !no_cargo_lock_checksums,
-                jobs,
+                prefetch_parallelism,
             };
             let build_info = crate2nix::BuildInfo::for_config(&generate_info, &generate_config)?;
             let nix_string = render::render_build_file(&build_info)?;

--- a/crate2nix/src/main.rs
+++ b/crate2nix/src/main.rs
@@ -77,6 +77,14 @@ pub enum Opt {
             help = "The path to the crate hash cache file. Uses 'crate-hashes.json' in the same directory as Cargo.toml by default."
         )]
         crate_hashes: Option<PathBuf>,
+
+        #[structopt(
+            short = "j",
+            long = "max-jobs",
+            default_value = "4",
+            help = "maximum concurrent fetch jobs"
+        )]
+        jobs: usize,
     },
 
     #[structopt(
@@ -115,6 +123,7 @@ fn main() -> CliResult {
             no_default_features,
             features,
             no_cargo_lock_checksums,
+            jobs,
         } => {
             let crate_hashes_json = crate_hashes.unwrap_or_else(|| {
                 cargo_toml
@@ -155,6 +164,7 @@ fn main() -> CliResult {
                 crate_hashes_json,
                 other_metadata_options,
                 use_cargo_lock_checksums: !no_cargo_lock_checksums,
+                jobs,
             };
             let build_info = crate2nix::BuildInfo::for_config(&generate_info, &generate_config)?;
             let nix_string = render::render_build_file(&build_info)?;

--- a/crate2nix/src/prefetch.rs
+++ b/crate2nix/src/prefetch.rs
@@ -147,19 +147,19 @@ impl<'a> Prefetcher<'a> {
         }
         if self.hashes != old_prefetched_hashes {
             std::fs::write(
-                &config.crate_hashes_json,
-                serde_json::to_vec_pretty(&hashes)?,
+                &self.config.crate_hashes_json,
+                serde_json::to_vec_pretty(&self.hashes)?,
             )
             .map_err(|e| {
                 format_err!(
                     "while writing hashes to {}: {}",
-                    config.crate_hashes_json.to_str().unwrap_or("<unknown>"),
+                    self.config.crate_hashes_json.to_str().unwrap_or("<unknown>"),
                     e
                 )
             })?;
             eprintln!(
                 "Wrote hashes to {}.",
-                config.crate_hashes_json.to_string_lossy()
+                self.config.crate_hashes_json.to_string_lossy()
             );
         }
 
@@ -187,7 +187,6 @@ impl<'a> Prefetcher<'a> {
         let defer = source.start_prefetch()?;
         self.fetch_queue.push_back((source, pkg_ids, defer));
         Ok(())
->>>>>>> ae478ae... Split out prefetch into multple methods on a ctx
     }
 
     fn dequeue(&mut self) -> Result<(), Error> {


### PR DESCRIPTION
This commit sketches out the alternative proposal for prefetching
sources in parallel. The trick used was to split up the `prefetch`
function for the sources into two separate `start_prefetch` and
`finish_prefetch` functions.

With those we can maintain a simple queue to ensure we never run more
than the specified number of jobs. That being said this implementation
has a deficiency in that it has head-of-the-line blocking problem (i.e.
if the earliest spawned pre-fetch blocks for a long time, and later ones
finish earlier, we fail to spawn more work.

I still think its an improvement of status quo, especially given how
little complexity it introduces.

cc @cpcloud @lovesegfault