### PR TITLE
Run tests from crate source directory

### DIFF
--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -83,6 +83,7 @@ rec {
         inherit testCrateFlags;
       } ''
         set -ex
+        cd ${crate.src}
         for file in ${drv}/tests/*; do
           $file $testCrateFlags 2>&1 | tee -a $out
         done


### PR DESCRIPTION
Crates written assuming cargo may also assume that the current working
directory is set to crate root when tests are being run.

This will make strictly more tests pass, although tests which write to
$PWD will still fail to run. This could be rectified by making a view in
`/tmp` or something, but its way beyond me to fix at this point in time.