### PR TITLE
regenerate_cargo_nix.sh: fix with channels

### DIFF
--- a/regenerate_cargo_nix.sh
+++ b/regenerate_cargo_nix.sh
@@ -19,7 +19,7 @@ nix build
 crate2nix="$(pwd)"/result/bin/crate2nix
 
 nix eval --json -f ./tests.nix buildTestConfigs | \
- nix run nixpkgs.jq -c jq -r .[].pregeneratedBuild | \
+ nix run -f '<nixpkgs>' jq -c jq -r .[].pregeneratedBuild | \
  while read cargo_nix; do
    if [ "$cargo_nix" = "null" ]; then
      continue


### PR DESCRIPTION
This workaround is required when using NIX_PATH pointing to a
directory, rather than individual named elements[1].  The fix[2] still
hasn't made it into a release.

[1]: https://github.com/NixOS/nix/issues/1865
[2]: https://github.com/NixOS/nix/commit/1d5cb6ad4839a50a96c27c94f19adcb97b6391af