### PR TITLE
cargo.sh: make rustfmt and clippy available

### DIFF
--- a/crate2nix/cargo.sh
+++ b/crate2nix/cargo.sh
@@ -8,4 +8,4 @@ set -Eeuo pipefail
 
 mydir=$(dirname "$0")
 
-nix run "(import $mydir/../nixpkgs.nix { config = {}; }).cargo" "(import $mydir/../nixpkgs.nix { config = {}; }).binutils" -c cargo "$@"
+nix run "(with import $mydir/../nixpkgs.nix { config = {}; }; [ cargo clippy rustfmt binutils ])" -c cargo "$@"


### PR DESCRIPTION
These are used by run_tests.sh.  It doesn't work in nix-shell without
these available.