### PR TITLE
Support providing `buildinputs` to test execution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,26 @@ able to add patches and the like! (I didn't try that, though.)
 `crateOverrides` are a feature of the underlying `buildRustCrate` support in
 NixOS that crate2nix uses.
 
+## Running rust tests
+
+There is some experimental support for running tests of your rust crates. All
+of the crates in the workspace will have their tests executed. When enabling
+test execution (`runTests = true;`) thests are a mandatory part of the build.
+
+```nix
+      let cargo_nix = callPackage ./Cargo.nix {};
+          crate2nix = cargo_nix.rootCrate.build.override {
+	    runTests = true;
+	    testInputs = [ pkgs.cowsay ];
+	  };
+      in ...
+```
+
+`testInputs` is optional and allows passing inputs to the test execution that
+should be in scope. Defaults to an empty list and is ignored when `runTests`
+equals `false`.
+
+
 ## Known Restrictions
 
 `crate2nix` makes heavy use of `buildRustCrate` in `nixpkgs`. So we potentially depend on features in a recent version

--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -2718,10 +2718,15 @@ rec {
         || baseName == "tests.nix"
       );
 
-  /* Returns a crate which depends on successful test execution 
-     of crate given as the second argument. 
+  /* Returns a crate which depends on successful test execution
+     of crate given as the second argument.
+
+     testCrateFlags: list of flags to pass to the test exectuable
+     testInputs: list of packages that should be available during test execution
   */
-  crateWithTest = crate: testCrate: testCrateFlags:
+  crateWithTest = { crate, testCrate, testCrateFlags, testInputs}:
+    assert builtins.typeOf testCrateFlags == "list";
+    assert builtins.typeOf testInputs == "list";
     let
       # override the `crate` so that it will build and execute tests instead of
       # building the actual lib and bin targets We just have to pass `--test`
@@ -2736,6 +2741,7 @@ rec {
       in
         pkgs.runCommand "run-tests-${testCrate.name}" {
           inherit testCrateFlags;
+          buildInputs = testInputs;
         } ''
           set -ex
           cd ${crate.src}
@@ -2769,10 +2775,11 @@ rec {
       )
     , runTests ? false
     , testCrateFlags ? []
+    , testInputs ? []
     }:
       lib.makeOverridable
         (
-          { features, crateOverrides, runTests, testCrateFlags }:
+          { features, crateOverrides, runTests, testCrateFlags, testInputs }:
             let
               builtRustCrates = builtRustCratesWithFeatures {
                 inherit packageId features buildRustCrateFunc;
@@ -2785,9 +2792,15 @@ rec {
               drv = builtRustCrates.${packageId};
               testDrv = builtTestRustCrates.${packageId};
             in
-              if runTests then crateWithTest drv testDrv testCrateFlags else drv
+              if runTests then
+                crateWithTest {
+                  crate = drv;
+                  testCrate = testDrv;
+                  inherit testCrateFlags testInputs;
+                }
+              else drv
         )
-        { inherit features crateOverrides runTests testCrateFlags; };
+        { inherit features crateOverrides runTests testCrateFlags testInputs; };
 
   /* Returns an attr set with packageId mapped to the result of buildRustCrateFunc 
      for the corresponding crate. 

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -184,10 +184,15 @@ rec {
         || baseName == "tests.nix"
       );
 
-  /* Returns a crate which depends on successful test execution 
-     of crate given as the second argument. 
+  /* Returns a crate which depends on successful test execution
+     of crate given as the second argument.
+
+     testCrateFlags: list of flags to pass to the test exectuable
+     testInputs: list of packages that should be available during test execution
   */
-  crateWithTest = crate: testCrate: testCrateFlags:
+  crateWithTest = { crate, testCrate, testCrateFlags, testInputs}:
+    assert builtins.typeOf testCrateFlags == "list";
+    assert builtins.typeOf testInputs == "list";
     let
       # override the `crate` so that it will build and execute tests instead of
       # building the actual lib and bin targets We just have to pass `--test`
@@ -202,6 +207,7 @@ rec {
       in
         pkgs.runCommand "run-tests-${testCrate.name}" {
           inherit testCrateFlags;
+          buildInputs = testInputs;
         } ''
           set -ex
           cd ${crate.src}
@@ -235,10 +241,11 @@ rec {
       )
     , runTests ? false
     , testCrateFlags ? []
+    , testInputs ? []
     }:
       lib.makeOverridable
         (
-          { features, crateOverrides, runTests, testCrateFlags }:
+          { features, crateOverrides, runTests, testCrateFlags, testInputs }:
             let
               builtRustCrates = builtRustCratesWithFeatures {
                 inherit packageId features buildRustCrateFunc;
@@ -251,9 +258,15 @@ rec {
               drv = builtRustCrates.${packageId};
               testDrv = builtTestRustCrates.${packageId};
             in
-              if runTests then crateWithTest drv testDrv testCrateFlags else drv
+              if runTests then
+                crateWithTest {
+                  crate = drv;
+                  testCrate = testDrv;
+                  inherit testCrateFlags testInputs;
+                }
+              else drv
         )
-        { inherit features crateOverrides runTests testCrateFlags; };
+        { inherit features crateOverrides runTests testCrateFlags testInputs; };
 
   /* Returns an attr set with packageId mapped to the result of buildRustCrateFunc 
      for the corresponding crate. 

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1358,10 +1358,15 @@ rec {
         || baseName == "tests.nix"
       );
 
-  /* Returns a crate which depends on successful test execution 
-     of crate given as the second argument. 
+  /* Returns a crate which depends on successful test execution
+     of crate given as the second argument.
+
+     testCrateFlags: list of flags to pass to the test exectuable
+     testInputs: list of packages that should be available during test execution
   */
-  crateWithTest = crate: testCrate: testCrateFlags:
+  crateWithTest = { crate, testCrate, testCrateFlags, testInputs}:
+    assert builtins.typeOf testCrateFlags == "list";
+    assert builtins.typeOf testInputs == "list";
     let
       # override the `crate` so that it will build and execute tests instead of
       # building the actual lib and bin targets We just have to pass `--test`
@@ -1376,6 +1381,7 @@ rec {
       in
         pkgs.runCommand "run-tests-${testCrate.name}" {
           inherit testCrateFlags;
+          buildInputs = testInputs;
         } ''
           set -ex
           cd ${crate.src}
@@ -1409,10 +1415,11 @@ rec {
       )
     , runTests ? false
     , testCrateFlags ? []
+    , testInputs ? []
     }:
       lib.makeOverridable
         (
-          { features, crateOverrides, runTests, testCrateFlags }:
+          { features, crateOverrides, runTests, testCrateFlags, testInputs }:
             let
               builtRustCrates = builtRustCratesWithFeatures {
                 inherit packageId features buildRustCrateFunc;
@@ -1425,9 +1432,15 @@ rec {
               drv = builtRustCrates.${packageId};
               testDrv = builtTestRustCrates.${packageId};
             in
-              if runTests then crateWithTest drv testDrv testCrateFlags else drv
+              if runTests then
+                crateWithTest {
+                  crate = drv;
+                  testCrate = testDrv;
+                  inherit testCrateFlags testInputs;
+                }
+              else drv
         )
-        { inherit features crateOverrides runTests testCrateFlags; };
+        { inherit features crateOverrides runTests testCrateFlags testInputs; };
 
   /* Returns an attr set with packageId mapped to the result of buildRustCrateFunc 
      for the corresponding crate. 

--- a/sample_projects/cfg-test/test.nix
+++ b/sample_projects/cfg-test/test.nix
@@ -5,4 +5,7 @@
 let
   instantiatedBuild = pkgs.callPackage generatedCargoNix {};
 in
-instantiatedBuild.rootCrate.build.override { runTests = true; }
+instantiatedBuild.rootCrate.build.override {
+  runTests = true;
+  testInputs = [ pkgs.cowsay ];
+}

--- a/sample_projects/cfg-test/tests/echo_foo_test.rs
+++ b/sample_projects/cfg-test/tests/echo_foo_test.rs
@@ -8,3 +8,8 @@ fn in_source_dir() {
     let path = std::path::Path::new("./snowflake.txt");
     assert!(path.exists())
 }
+
+#[test]
+fn exec_cowsay() {
+    std::process::Command::new("cowsay").spawn().unwrap();
+}

--- a/tests.nix
+++ b/tests.nix
@@ -182,6 +182,7 @@ let
         "test echo_foo_test ... ok"
         "test lib_test ... ok"
         "test in_source_dir ... ok"
+        "test exec_cowsay ... ok"
       ];
       customBuild = "sample_projects/cfg-test/test.nix";
     }


### PR DESCRIPTION
This allows users to add `buildInputs` to the test execution. This might
be required as during test execution external programs will be called on
generated output or in cases where the rust application is just a
wrapper around some other tool (in some way or another).