### PR TITLE
Parameterize local source fetcher

### DIFF
--- a/crate2nix/templates/build.nix.tera
+++ b/crate2nix/templates/build.nix.tera
@@ -15,6 +15,7 @@
 , rootFeatures ? [ "default" ]
   # If true, throw errors instead of issueing deprecation warnings.
 , strictDeprecation ? false
+, getCleanedSource ? null
 }:
 
 rec {
@@ -102,7 +103,7 @@ rec {
         {%- if crate.source.CratesIo.sha256 %}
         sha256 = {{crate.source.CratesIo.sha256}};
         {%- elif crate.source.LocalDirectory.path %}
-        src = (builtins.filterSource sourceFilter {{crate.source.LocalDirectory.path | safe}});
+        src = getLocalSource {{crate.source.LocalDirectory.path | safe}};
         {%- elif crate.source.Git %}
         src = pkgs.fetchgit {
           url = {{crate.source.Git.url}};

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -38,6 +38,10 @@ rec {
     debug_assertions = false;
   };
 
+  getLocalSource = if getCleanedSource == null
+    then builtins.filterSource sourceFilter
+    else getCleanedSource;
+
   /* Filters common temp files and build files. */
   # TODO(pkolloch): Substitute with gitignore filter
   sourceFilter = name: type:


### PR DESCRIPTION
The project I'm using `crate2nix` for already has some stuff set up for source filtering using `git ls-files` and so on, so this makes it a lot easier to use that as a drop-in replacement for the bundled source filter.