### PR TITLE
use lib.concatMap instead of builtins.concatMap

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -3147,7 +3147,7 @@ rec {
       expandFeature = feature:
         assert (builtins.isString feature);
         [ feature ] ++ (expandFeatures featureMap (featureMap."${feature}" or []));
-      outFeatures = builtins.concatMap expandFeature inputFeatures;
+      outFeatures = lib.concatMap expandFeature inputFeatures;
     in
       sortedUnique outFeatures;
 

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -512,7 +512,7 @@ rec {
       expandFeature = feature:
         assert (builtins.isString feature);
         [ feature ] ++ (expandFeatures featureMap (featureMap."${feature}" or []));
-      outFeatures = builtins.concatMap expandFeature inputFeatures;
+      outFeatures = lib.concatMap expandFeature inputFeatures;
     in
       sortedUnique outFeatures;
 

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -614,7 +614,7 @@ rec {
       expandFeature = feature:
         assert (builtins.isString feature);
         [ feature ] ++ (expandFeatures featureMap (featureMap."${feature}" or []));
-      outFeatures = builtins.concatMap expandFeature inputFeatures;
+      outFeatures = lib.concatMap expandFeature inputFeatures;
     in
       sortedUnique outFeatures;
 

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1787,7 +1787,7 @@ rec {
       expandFeature = feature:
         assert (builtins.isString feature);
         [ feature ] ++ (expandFeatures featureMap (featureMap."${feature}" or []));
-      outFeatures = builtins.concatMap expandFeature inputFeatures;
+      outFeatures = lib.concatMap expandFeature inputFeatures;
     in
       sortedUnique outFeatures;
 

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -966,7 +966,7 @@ rec {
       expandFeature = feature:
         assert (builtins.isString feature);
         [ feature ] ++ (expandFeatures featureMap (featureMap."${feature}" or []));
-      outFeatures = builtins.concatMap expandFeature inputFeatures;
+      outFeatures = lib.concatMap expandFeature inputFeatures;
     in
       sortedUnique outFeatures;
 

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -633,7 +633,7 @@ rec {
       expandFeature = feature:
         assert (builtins.isString feature);
         [ feature ] ++ (expandFeatures featureMap (featureMap."${feature}" or []));
-      outFeatures = builtins.concatMap expandFeature inputFeatures;
+      outFeatures = lib.concatMap expandFeature inputFeatures;
     in
       sortedUnique outFeatures;
 


### PR DESCRIPTION
travis has nix 2.0.4 which does not have the latter.