### PR TITLE
Add support for target_feature cfgs

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -14,6 +14,8 @@
 , rootFeatures ? [ "default" ]
   # If true, throw errors instead of issueing deprecation warnings.
 , strictDeprecation ? false
+  # Used for conditional compilation based on CPU feature detection.
+, targetFeatures ? []
   # Whether to perform release builds: longer compile times, faster binaries.
 , release ? true
   # Additional crate2nix configuration if it exists.
@@ -2467,6 +2469,7 @@ rec {
                       crateConfig.sha256;
                   }
                 );
+                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${stdenv.lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
                 inherit features dependencies buildDependencies crateRenames release;
               }
             );

--- a/crate2nix/src/render.rs
+++ b/crate2nix/src/render.rs
@@ -210,6 +210,8 @@ fn cfg_to_nix_expr(cfg: &CfgExpr) -> String {
                 let escaped_value = escape_nix_string(value);
                 result.push_str(&if key == "feature" {
                     format!("(builtins.elem {} features)", escaped_value)
+                } else if key == "target_feature" {
+                    format!("(builtins.elem {} targetFeatures)", escaped_value)
                 } else {
                     format!("(target.{} == {})", target(key), escaped_value)
                 });
@@ -257,6 +259,13 @@ fn test_render_cfg_to_nix_expr() {
     }
 
     assert_eq!("target.\"unix\"", &cfg_to_nix_expr(&name("unix")));
+    assert_eq!(
+        "((builtins.elem \"aes\" targetFeatures) && (builtins.elem \"foo\" features))",
+        &cfg_to_nix_expr(&CfgExpr::All(vec![
+            kv("target_feature", "aes"),
+            kv("feature", "foo")
+        ]))
+    );
     assert_eq!(
         "(target.\"os\" == \"linux\")",
         &cfg_to_nix_expr(&kv("target_os", "linux"))

--- a/crate2nix/templates/Cargo.nix.tera
+++ b/crate2nix/templates/Cargo.nix.tera
@@ -16,6 +16,8 @@
 , rootFeatures ? [ "default" ]
   # If true, throw errors instead of issueing deprecation warnings.
 , strictDeprecation ? false
+  # Used for conditional compilation based on CPU feature detection.
+, targetFeatures ? []
   # Whether to perform release builds: longer compile times, faster binaries.
 , release ? true
   # Additional crate2nix configuration if it exists.

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -9,6 +9,7 @@
 , strictDeprecation ? true
 , crates ? { }
 , rootFeatures ? [ ]
+, targetFeatures ? [ ]
 , release ? true
 }:
 rec {
@@ -311,6 +312,7 @@ rec {
                       crateConfig.sha256;
                   }
                 );
+                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${stdenv.lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
                 inherit features dependencies buildDependencies crateRenames release;
               }
             );

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -14,6 +14,8 @@
 , rootFeatures ? [ "default" ]
   # If true, throw errors instead of issueing deprecation warnings.
 , strictDeprecation ? false
+  # Used for conditional compilation based on CPU feature detection.
+, targetFeatures ? []
   # Whether to perform release builds: longer compile times, faster binaries.
 , release ? true
   # Additional crate2nix configuration if it exists.
@@ -418,6 +420,7 @@ rec {
                       crateConfig.sha256;
                   }
                 );
+                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${stdenv.lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
                 inherit features dependencies buildDependencies crateRenames release;
               }
             );

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -14,6 +14,8 @@
 , rootFeatures ? [ "default" ]
   # If true, throw errors instead of issueing deprecation warnings.
 , strictDeprecation ? false
+  # Used for conditional compilation based on CPU feature detection.
+, targetFeatures ? []
   # Whether to perform release builds: longer compile times, faster binaries.
 , release ? true
   # Additional crate2nix configuration if it exists.
@@ -1591,6 +1593,7 @@ rec {
                       crateConfig.sha256;
                   }
                 );
+                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${stdenv.lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
                 inherit features dependencies buildDependencies crateRenames release;
               }
             );

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -14,6 +14,8 @@
 , rootFeatures ? [ "default" ]
   # If true, throw errors instead of issueing deprecation warnings.
 , strictDeprecation ? false
+  # Used for conditional compilation based on CPU feature detection.
+, targetFeatures ? []
   # Whether to perform release builds: longer compile times, faster binaries.
 , release ? true
   # Additional crate2nix configuration if it exists.
@@ -770,6 +772,7 @@ rec {
                       crateConfig.sha256;
                   }
                 );
+                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${stdenv.lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
                 inherit features dependencies buildDependencies crateRenames release;
               }
             );

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -14,6 +14,8 @@
 , rootFeatures ? [ "default" ]
   # If true, throw errors instead of issueing deprecation warnings.
 , strictDeprecation ? false
+  # Used for conditional compilation based on CPU feature detection.
+, targetFeatures ? []
   # Whether to perform release builds: longer compile times, faster binaries.
 , release ? true
   # Additional crate2nix configuration if it exists.
@@ -437,6 +439,7 @@ rec {
                       crateConfig.sha256;
                   }
                 );
+                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${stdenv.lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
                 inherit features dependencies buildDependencies crateRenames release;
               }
             );


### PR DESCRIPTION
This PR adds support for [target-feature](https://doc.rust-lang.org/rustc/codegen-options/index.html#target-feature) cfgs, by allowing users to specify the target features manually. As the [gotchas page](https://doc.rust-lang.org/rustc/targets/known-issues.html) notes this is potentially unsafe, so I'm very open to suggestions on more automated / safer ways to do this. 

My use case is a project that depends on the `sha` crate, which runs fine when I supply `[ "sha" "sse2" ]` as targetFeatures.

This fixes #136.
