### PR TITLE
WIP: add support for cross-compilation

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -7,7 +7,6 @@
 , pkgs ? import nixpkgs { config = {}; }
 , lib ? pkgs.lib
 , stdenv ? pkgs.stdenv
-, buildRustCrate ? pkgs.buildRustCrate
   # This is used as the `crateOverrides` argument for `buildRustCrate`.
 , defaultCrateOverrides ? pkgs.defaultCrateOverrides
   # The features to enable for the root_crate or the workspace_members.
@@ -2291,7 +2290,6 @@ rec {
     { packageId
     , features ? rootFeatures
     , crateOverrides ? defaultCrateOverrides
-    , buildRustCrateFunc ? null
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
@@ -2305,26 +2303,18 @@ rec {
         , testInputs
         }:
         let
-          buildRustCrateFuncOverriden =
-            if buildRustCrateFunc != null
-            then buildRustCrateFunc
-            else
-              (
-                if crateOverrides == pkgs.defaultCrateOverrides
-                then buildRustCrate
-                else
-                  buildRustCrate.override {
-                    defaultCrateOverrides = crateOverrides;
-                  }
-              );
+          buildRustCrateOverrides =
+            if crateOverrides == pkgs.defaultCrateOverrides
+            then { }
+            else {
+              defaultCrateOverrides = crateOverrides;
+            };
           builtRustCrates = builtRustCratesWithFeatures {
-            inherit packageId features;
-            buildRustCrateFunc = buildRustCrateFuncOverriden;
+            inherit packageId features buildRustCrateOverrides;
             runTests = false;
           };
           builtTestRustCrates = builtRustCratesWithFeatures {
-            inherit packageId features;
-            buildRustCrateFunc = buildRustCrateFuncOverriden;
+            inherit packageId features buildRustCrateOverrides;
             runTests = true;
           };
           drv = builtRustCrates.${packageId};
@@ -2350,7 +2340,7 @@ rec {
     { packageId
     , features
     , crateConfigs ? crates
-    , buildRustCrateFunc
+    , buildRustCrateOverrides
     , runTests
     , target ? defaultTarget
     } @ args:
@@ -2368,13 +2358,10 @@ rec {
               target = target // { test = runTests; };
             }
           );
-        buildByPackageId = packageId: buildByPackageIdImpl packageId;
-
-        # Memoize built packages so that reappearing packages are only built once.
-        builtByPackageId =
-          lib.mapAttrs (packageId: value: buildByPackageId packageId) crateConfigs;
-        buildByPackageIdImpl = packageId:
+        buildByPackageIdForPkgs = pkgs: packageId:
           let
+            # proc_macro crates must be compiled for the build architecture
+            cratePkgs = if crateConfig.procMacro or false then pkgs.buildPackages else pkgs;
             features = mergedFeatures."${packageId}" or [ ];
             crateConfig' = crateConfigs."${packageId}";
             crateConfig =
@@ -2385,14 +2372,16 @@ rec {
                 (crateConfig'.devDependencies or [ ]);
             dependencies =
               dependencyDerivations {
-                inherit builtByPackageId features target;
+                inherit features target;
+                buildByPackageId = buildByPackageIdForPkgs cratePkgs;
                 dependencies =
                   (crateConfig.dependencies or [ ])
                   ++ devDependencies;
               };
             buildDependencies =
               dependencyDerivations {
-                inherit builtByPackageId features target;
+                inherit features target;
+                buildByPackageId = buildByPackageIdForPkgs cratePkgs.buildPackages;
                 dependencies = crateConfig.buildDependencies or [ ];
               };
             filterEnabledDependenciesForThis = dependencies: filterEnabledDependencies {
@@ -2424,13 +2413,13 @@ rec {
                     dependenciesWithRenames;
                 versionAndRename = dep:
                   let
-                    package = builtByPackageId."${dep.packageId}";
+                    package = crateConfigs."${dep.packageId}";
                   in
                   { inherit (dep) rename; version = package.version; };
               in
               lib.mapAttrs (name: choices: builtins.map versionAndRename choices) grouped;
           in
-          buildRustCrateFunc
+          cratePkgs.buildRustCrate.override buildRustCrateOverrides
             (
               crateConfig // {
                 src = crateConfig.src or (
@@ -2449,16 +2438,15 @@ rec {
               }
             );
       in
-      builtByPackageId;
+      lib.mapAttrs (packageId: value: buildByPackageIdForPkgs pkgs packageId) crateConfigs;
 
   /* Returns the actual derivations for the given dependencies. */
   dependencyDerivations =
-    { builtByPackageId
+    { buildByPackageId
     , features
     , dependencies
     , target
     }:
-      assert (builtins.isAttrs builtByPackageId);
       assert (builtins.isList features);
       assert (builtins.isList dependencies);
       assert (builtins.isAttrs target);
@@ -2466,7 +2454,7 @@ rec {
         enabledDependencies = filterEnabledDependencies {
           inherit dependencies features target;
         };
-        depDerivation = dependency: builtByPackageId.${dependency.packageId};
+        depDerivation = dependency: buildByPackageId dependency.packageId;
       in
       map depDerivation enabledDependencies;
 

--- a/crate2nix/templates/Cargo.nix.tera
+++ b/crate2nix/templates/Cargo.nix.tera
@@ -9,7 +9,6 @@
 , pkgs ? import nixpkgs { config = {}; }
 , lib ? pkgs.lib
 , stdenv ? pkgs.stdenv
-, buildRustCrate ? pkgs.buildRustCrate
   # This is used as the `crateOverrides` argument for `buildRustCrate`.
 , defaultCrateOverrides ? pkgs.defaultCrateOverrides
   # The features to enable for the root_crate or the workspace_members.

--- a/crate2nix/templates/nix/crate2nix/tests/dependencyDerivations.nix
+++ b/crate2nix/templates/nix/crate2nix/tests/dependencyDerivations.nix
@@ -1,10 +1,10 @@
 { lib, crate2nix }:
 let
-  fakeCrates = {
+  fakeCrates = packageId: {
     "pkg_id1" = "pkg_id1";
     "pkg_id2" = "pkg_id2";
     "pkg_id3" = "pkg_id3";
-  };
+  }.${packageId};
   fakeDependencies = [
     {
       name = "id1";
@@ -23,7 +23,7 @@ let
   ];
   dependencyDerivations = features: dependencies:
     crate2nix.dependencyDerivations {
-      builtByPackageId = fakeCrates;
+      buildByPackageId = fakeCrates;
       target = crate2nix.defaultTarget;
       inherit features dependencies;
     };

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -7,7 +7,6 @@
 , pkgs ? import nixpkgs { config = {}; }
 , lib ? pkgs.lib
 , stdenv ? pkgs.stdenv
-, buildRustCrate ? pkgs.buildRustCrate
   # This is used as the `crateOverrides` argument for `buildRustCrate`.
 , defaultCrateOverrides ? pkgs.defaultCrateOverrides
   # The features to enable for the root_crate or the workspace_members.
@@ -270,7 +269,6 @@ rec {
     { packageId
     , features ? rootFeatures
     , crateOverrides ? defaultCrateOverrides
-    , buildRustCrateFunc ? null
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
@@ -284,26 +282,18 @@ rec {
         , testInputs
         }:
         let
-          buildRustCrateFuncOverriden =
-            if buildRustCrateFunc != null
-            then buildRustCrateFunc
-            else
-              (
-                if crateOverrides == pkgs.defaultCrateOverrides
-                then buildRustCrate
-                else
-                  buildRustCrate.override {
-                    defaultCrateOverrides = crateOverrides;
-                  }
-              );
+          buildRustCrateOverrides =
+            if crateOverrides == pkgs.defaultCrateOverrides
+            then { }
+            else {
+              defaultCrateOverrides = crateOverrides;
+            };
           builtRustCrates = builtRustCratesWithFeatures {
-            inherit packageId features;
-            buildRustCrateFunc = buildRustCrateFuncOverriden;
+            inherit packageId features buildRustCrateOverrides;
             runTests = false;
           };
           builtTestRustCrates = builtRustCratesWithFeatures {
-            inherit packageId features;
-            buildRustCrateFunc = buildRustCrateFuncOverriden;
+            inherit packageId features buildRustCrateOverrides;
             runTests = true;
           };
           drv = builtRustCrates.${packageId};
@@ -329,7 +319,7 @@ rec {
     { packageId
     , features
     , crateConfigs ? crates
-    , buildRustCrateFunc
+    , buildRustCrateOverrides
     , runTests
     , target ? defaultTarget
     } @ args:
@@ -347,13 +337,10 @@ rec {
               target = target // { test = runTests; };
             }
           );
-        buildByPackageId = packageId: buildByPackageIdImpl packageId;
-
-        # Memoize built packages so that reappearing packages are only built once.
-        builtByPackageId =
-          lib.mapAttrs (packageId: value: buildByPackageId packageId) crateConfigs;
-        buildByPackageIdImpl = packageId:
+        buildByPackageIdForPkgs = pkgs: packageId:
           let
+            # proc_macro crates must be compiled for the build architecture
+            cratePkgs = if crateConfig.procMacro or false then pkgs.buildPackages else pkgs;
             features = mergedFeatures."${packageId}" or [ ];
             crateConfig' = crateConfigs."${packageId}";
             crateConfig =
@@ -364,14 +351,16 @@ rec {
                 (crateConfig'.devDependencies or [ ]);
             dependencies =
               dependencyDerivations {
-                inherit builtByPackageId features target;
+                inherit features target;
+                buildByPackageId = buildByPackageIdForPkgs cratePkgs;
                 dependencies =
                   (crateConfig.dependencies or [ ])
                   ++ devDependencies;
               };
             buildDependencies =
               dependencyDerivations {
-                inherit builtByPackageId features target;
+                inherit features target;
+                buildByPackageId = buildByPackageIdForPkgs cratePkgs.buildPackages;
                 dependencies = crateConfig.buildDependencies or [ ];
               };
             filterEnabledDependenciesForThis = dependencies: filterEnabledDependencies {
@@ -403,13 +392,13 @@ rec {
                     dependenciesWithRenames;
                 versionAndRename = dep:
                   let
-                    package = builtByPackageId."${dep.packageId}";
+                    package = crateConfigs."${dep.packageId}";
                   in
                   { inherit (dep) rename; version = package.version; };
               in
               lib.mapAttrs (name: choices: builtins.map versionAndRename choices) grouped;
           in
-          buildRustCrateFunc
+          cratePkgs.buildRustCrate.override buildRustCrateOverrides
             (
               crateConfig // {
                 src = crateConfig.src or (
@@ -428,16 +417,15 @@ rec {
               }
             );
       in
-      builtByPackageId;
+      lib.mapAttrs (packageId: value: buildByPackageIdForPkgs pkgs packageId) crateConfigs;
 
   /* Returns the actual derivations for the given dependencies. */
   dependencyDerivations =
-    { builtByPackageId
+    { buildByPackageId
     , features
     , dependencies
     , target
     }:
-      assert (builtins.isAttrs builtByPackageId);
       assert (builtins.isList features);
       assert (builtins.isList dependencies);
       assert (builtins.isAttrs target);
@@ -445,7 +433,7 @@ rec {
         enabledDependencies = filterEnabledDependencies {
           inherit dependencies features target;
         };
-        depDerivation = dependency: builtByPackageId.${dependency.packageId};
+        depDerivation = dependency: buildByPackageId dependency.packageId;
       in
       map depDerivation enabledDependencies;
 

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -7,7 +7,6 @@
 , pkgs ? import nixpkgs { config = {}; }
 , lib ? pkgs.lib
 , stdenv ? pkgs.stdenv
-, buildRustCrate ? pkgs.buildRustCrate
   # This is used as the `crateOverrides` argument for `buildRustCrate`.
 , defaultCrateOverrides ? pkgs.defaultCrateOverrides
   # The features to enable for the root_crate or the workspace_members.
@@ -1443,7 +1442,6 @@ rec {
     { packageId
     , features ? rootFeatures
     , crateOverrides ? defaultCrateOverrides
-    , buildRustCrateFunc ? null
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
@@ -1457,26 +1455,18 @@ rec {
         , testInputs
         }:
         let
-          buildRustCrateFuncOverriden =
-            if buildRustCrateFunc != null
-            then buildRustCrateFunc
-            else
-              (
-                if crateOverrides == pkgs.defaultCrateOverrides
-                then buildRustCrate
-                else
-                  buildRustCrate.override {
-                    defaultCrateOverrides = crateOverrides;
-                  }
-              );
+          buildRustCrateOverrides =
+            if crateOverrides == pkgs.defaultCrateOverrides
+            then { }
+            else {
+              defaultCrateOverrides = crateOverrides;
+            };
           builtRustCrates = builtRustCratesWithFeatures {
-            inherit packageId features;
-            buildRustCrateFunc = buildRustCrateFuncOverriden;
+            inherit packageId features buildRustCrateOverrides;
             runTests = false;
           };
           builtTestRustCrates = builtRustCratesWithFeatures {
-            inherit packageId features;
-            buildRustCrateFunc = buildRustCrateFuncOverriden;
+            inherit packageId features buildRustCrateOverrides;
             runTests = true;
           };
           drv = builtRustCrates.${packageId};
@@ -1502,7 +1492,7 @@ rec {
     { packageId
     , features
     , crateConfigs ? crates
-    , buildRustCrateFunc
+    , buildRustCrateOverrides
     , runTests
     , target ? defaultTarget
     } @ args:
@@ -1520,13 +1510,10 @@ rec {
               target = target // { test = runTests; };
             }
           );
-        buildByPackageId = packageId: buildByPackageIdImpl packageId;
-
-        # Memoize built packages so that reappearing packages are only built once.
-        builtByPackageId =
-          lib.mapAttrs (packageId: value: buildByPackageId packageId) crateConfigs;
-        buildByPackageIdImpl = packageId:
+        buildByPackageIdForPkgs = pkgs: packageId:
           let
+            # proc_macro crates must be compiled for the build architecture
+            cratePkgs = if crateConfig.procMacro or false then pkgs.buildPackages else pkgs;
             features = mergedFeatures."${packageId}" or [ ];
             crateConfig' = crateConfigs."${packageId}";
             crateConfig =
@@ -1537,14 +1524,16 @@ rec {
                 (crateConfig'.devDependencies or [ ]);
             dependencies =
               dependencyDerivations {
-                inherit builtByPackageId features target;
+                inherit features target;
+                buildByPackageId = buildByPackageIdForPkgs cratePkgs;
                 dependencies =
                   (crateConfig.dependencies or [ ])
                   ++ devDependencies;
               };
             buildDependencies =
               dependencyDerivations {
-                inherit builtByPackageId features target;
+                inherit features target;
+                buildByPackageId = buildByPackageIdForPkgs cratePkgs.buildPackages;
                 dependencies = crateConfig.buildDependencies or [ ];
               };
             filterEnabledDependenciesForThis = dependencies: filterEnabledDependencies {
@@ -1576,13 +1565,13 @@ rec {
                     dependenciesWithRenames;
                 versionAndRename = dep:
                   let
-                    package = builtByPackageId."${dep.packageId}";
+                    package = crateConfigs."${dep.packageId}";
                   in
                   { inherit (dep) rename; version = package.version; };
               in
               lib.mapAttrs (name: choices: builtins.map versionAndRename choices) grouped;
           in
-          buildRustCrateFunc
+          cratePkgs.buildRustCrate.override buildRustCrateOverrides
             (
               crateConfig // {
                 src = crateConfig.src or (
@@ -1601,16 +1590,15 @@ rec {
               }
             );
       in
-      builtByPackageId;
+      lib.mapAttrs (packageId: value: buildByPackageIdForPkgs pkgs packageId) crateConfigs;
 
   /* Returns the actual derivations for the given dependencies. */
   dependencyDerivations =
-    { builtByPackageId
+    { buildByPackageId
     , features
     , dependencies
     , target
     }:
-      assert (builtins.isAttrs builtByPackageId);
       assert (builtins.isList features);
       assert (builtins.isList dependencies);
       assert (builtins.isAttrs target);
@@ -1618,7 +1606,7 @@ rec {
         enabledDependencies = filterEnabledDependencies {
           inherit dependencies features target;
         };
-        depDerivation = dependency: builtByPackageId.${dependency.packageId};
+        depDerivation = dependency: buildByPackageId dependency.packageId;
       in
       map depDerivation enabledDependencies;
 

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -7,7 +7,6 @@
 , pkgs ? import nixpkgs { config = {}; }
 , lib ? pkgs.lib
 , stdenv ? pkgs.stdenv
-, buildRustCrate ? pkgs.buildRustCrate
   # This is used as the `crateOverrides` argument for `buildRustCrate`.
 , defaultCrateOverrides ? pkgs.defaultCrateOverrides
   # The features to enable for the root_crate or the workspace_members.
@@ -622,7 +621,6 @@ rec {
     { packageId
     , features ? rootFeatures
     , crateOverrides ? defaultCrateOverrides
-    , buildRustCrateFunc ? null
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
@@ -636,26 +634,18 @@ rec {
         , testInputs
         }:
         let
-          buildRustCrateFuncOverriden =
-            if buildRustCrateFunc != null
-            then buildRustCrateFunc
-            else
-              (
-                if crateOverrides == pkgs.defaultCrateOverrides
-                then buildRustCrate
-                else
-                  buildRustCrate.override {
-                    defaultCrateOverrides = crateOverrides;
-                  }
-              );
+          buildRustCrateOverrides =
+            if crateOverrides == pkgs.defaultCrateOverrides
+            then { }
+            else {
+              defaultCrateOverrides = crateOverrides;
+            };
           builtRustCrates = builtRustCratesWithFeatures {
-            inherit packageId features;
-            buildRustCrateFunc = buildRustCrateFuncOverriden;
+            inherit packageId features buildRustCrateOverrides;
             runTests = false;
           };
           builtTestRustCrates = builtRustCratesWithFeatures {
-            inherit packageId features;
-            buildRustCrateFunc = buildRustCrateFuncOverriden;
+            inherit packageId features buildRustCrateOverrides;
             runTests = true;
           };
           drv = builtRustCrates.${packageId};
@@ -681,7 +671,7 @@ rec {
     { packageId
     , features
     , crateConfigs ? crates
-    , buildRustCrateFunc
+    , buildRustCrateOverrides
     , runTests
     , target ? defaultTarget
     } @ args:
@@ -699,13 +689,10 @@ rec {
               target = target // { test = runTests; };
             }
           );
-        buildByPackageId = packageId: buildByPackageIdImpl packageId;
-
-        # Memoize built packages so that reappearing packages are only built once.
-        builtByPackageId =
-          lib.mapAttrs (packageId: value: buildByPackageId packageId) crateConfigs;
-        buildByPackageIdImpl = packageId:
+        buildByPackageIdForPkgs = pkgs: packageId:
           let
+            # proc_macro crates must be compiled for the build architecture
+            cratePkgs = if crateConfig.procMacro or false then pkgs.buildPackages else pkgs;
             features = mergedFeatures."${packageId}" or [ ];
             crateConfig' = crateConfigs."${packageId}";
             crateConfig =
@@ -716,14 +703,16 @@ rec {
                 (crateConfig'.devDependencies or [ ]);
             dependencies =
               dependencyDerivations {
-                inherit builtByPackageId features target;
+                inherit features target;
+                buildByPackageId = buildByPackageIdForPkgs cratePkgs;
                 dependencies =
                   (crateConfig.dependencies or [ ])
                   ++ devDependencies;
               };
             buildDependencies =
               dependencyDerivations {
-                inherit builtByPackageId features target;
+                inherit features target;
+                buildByPackageId = buildByPackageIdForPkgs cratePkgs.buildPackages;
                 dependencies = crateConfig.buildDependencies or [ ];
               };
             filterEnabledDependenciesForThis = dependencies: filterEnabledDependencies {
@@ -755,13 +744,13 @@ rec {
                     dependenciesWithRenames;
                 versionAndRename = dep:
                   let
-                    package = builtByPackageId."${dep.packageId}";
+                    package = crateConfigs."${dep.packageId}";
                   in
                   { inherit (dep) rename; version = package.version; };
               in
               lib.mapAttrs (name: choices: builtins.map versionAndRename choices) grouped;
           in
-          buildRustCrateFunc
+          cratePkgs.buildRustCrate.override buildRustCrateOverrides
             (
               crateConfig // {
                 src = crateConfig.src or (
@@ -780,16 +769,15 @@ rec {
               }
             );
       in
-      builtByPackageId;
+      lib.mapAttrs (packageId: value: buildByPackageIdForPkgs pkgs packageId) crateConfigs;
 
   /* Returns the actual derivations for the given dependencies. */
   dependencyDerivations =
-    { builtByPackageId
+    { buildByPackageId
     , features
     , dependencies
     , target
     }:
-      assert (builtins.isAttrs builtByPackageId);
       assert (builtins.isList features);
       assert (builtins.isList dependencies);
       assert (builtins.isAttrs target);
@@ -797,7 +785,7 @@ rec {
         enabledDependencies = filterEnabledDependencies {
           inherit dependencies features target;
         };
-        depDerivation = dependency: builtByPackageId.${dependency.packageId};
+        depDerivation = dependency: buildByPackageId dependency.packageId;
       in
       map depDerivation enabledDependencies;
 


### PR DESCRIPTION
This adds support for cross-compiling using crate2nix to Linux targets. With this PR, passing `pkgs = pkgsCross.<platform>` to the generated `Cargo.nix` will cross-compile the crate.

Unfortunately, I haven't figured out a way to do this without potentially breaking existing users, as well as the debugging tools. This is because there is no longer a single version of `buildRustCrate` used by all crates, and instead there are separate ones for each platform. This makes it difficult to pass around `buildRustCrateFunc`.

This PR also includes #142 because I needed it to test some of my crates.