### PR TITLE
tools.nix: compare Nix version with 2.3

### DIFF
--- a/tools.nix
+++ b/tools.nix
@@ -245,8 +245,9 @@ rec {
             value = builtins.readFile hash;
           };
 
+        # Fetching git submodules with builtins.fetchGit is only supported in nix > 2.3
         extraHashes = lib.optionalAttrs
-          ((builtins.elemAt (builtins.splitVersion builtins.nixVersion) 0) == "3")
+          (builtins.compareVersions builtins.nixVersion "2.3" == 1)
           (builtins.listToAttrs (map mkGitHash unhashedGitDeps));
 
         packages =


### PR DESCRIPTION
Previously, the new Nix release would be called 3.0. Now the version
is 2.4pre, which means that matching the major version with 3 to
determine if new features are available is incorrect.

Tested on balsoft/simple-osd-daemons, without this patch it fails to fetch `mpris` dependency via git and with this patch everything builds correctly.