### PR TITLE
fix test regression

### DIFF
--- a/crate2nix/src/render.rs
+++ b/crate2nix/src/render.rs
@@ -258,7 +258,10 @@ fn test_render_cfg_to_nix_expr() {
         CfgExpr::Value(KeyPair(key.to_string(), value.to_string()))
     }
 
-    assert_eq!("target.\"unix\"", &cfg_to_nix_expr(&name("unix")));
+    assert_eq!(
+        "(target.\"unix\" or false)",
+        &cfg_to_nix_expr(&name("unix"))
+    );
     assert_eq!(
         "((builtins.elem \"aes\" targetFeatures) && (builtins.elem \"foo\" features))",
         &cfg_to_nix_expr(&CfgExpr::All(vec![
@@ -275,11 +278,11 @@ fn test_render_cfg_to_nix_expr() {
         &cfg_to_nix_expr(&CfgExpr::Not(Box::new(kv("target_os", "linux"))))
     );
     assert_eq!(
-        "(target.\"unix\" || (target.\"os\" == \"linux\"))",
+        "((target.\"unix\" or false) || (target.\"os\" == \"linux\"))",
         &cfg_to_nix_expr(&CfgExpr::Any(vec![name("unix"), kv("target_os", "linux")]))
     );
     assert_eq!(
-        "(target.\"unix\" && (target.\"os\" == \"linux\"))",
+        "((target.\"unix\" or false) && (target.\"os\" == \"linux\"))",
         &cfg_to_nix_expr(&CfgExpr::All(vec![name("unix"), kv("target_os", "linux")]))
     );
 }


### PR DESCRIPTION
Fixed a unit test regressed by #157.
This regression seems to slip through the CI due to [`--no-cargo-build`](https://github.com/kolloch/crate2nix/blob/509918492f7c5e6cff1697e1857a383f46bf6a76/.github/workflows/tests-nix-linux.yml#L21).