### PR TITLE
Switch to NixOS/nixpkgs

### DIFF
--- a/crate2nix/src/render.rs
+++ b/crate2nix/src/render.rs
@@ -258,7 +258,10 @@ fn test_render_cfg_to_nix_expr() {
         CfgExpr::Value(KeyPair(key.to_string(), value.to_string()))
     }
 
-    assert_eq!("target.\"unix\"", &cfg_to_nix_expr(&name("unix")));
+    assert_eq!(
+        "(target.\"unix\" or false)",
+        &cfg_to_nix_expr(&name("unix"))
+    );
     assert_eq!(
         "((builtins.elem \"aes\" targetFeatures) && (builtins.elem \"foo\" features))",
         &cfg_to_nix_expr(&CfgExpr::All(vec![
@@ -275,11 +278,11 @@ fn test_render_cfg_to_nix_expr() {
         &cfg_to_nix_expr(&CfgExpr::Not(Box::new(kv("target_os", "linux"))))
     );
     assert_eq!(
-        "(target.\"unix\" || (target.\"os\" == \"linux\"))",
+        "((target.\"unix\" or false) || (target.\"os\" == \"linux\"))",
         &cfg_to_nix_expr(&CfgExpr::Any(vec![name("unix"), kv("target_os", "linux")]))
     );
     assert_eq!(
-        "(target.\"unix\" && (target.\"os\" == \"linux\"))",
+        "((target.\"unix\" or false) && (target.\"os\" == \"linux\"))",
         &cfg_to_nix_expr(&CfgExpr::All(vec![name("unix"), kv("target_os", "linux")]))
     );
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "ba57d5a29b4e0f2085917010380ef3ddc3cf380f",
-        "sha256": "1kpsvc53x821cmjg1khvp1nz7906gczq8mp83664cr15h94sh8i4",
+        "rev": "af958e8057f345ee1aca714c1247ef3ba1c15f5e",
+        "sha256": "1qjavxabbrsh73yck5dcq8jggvh3r2jkbr6b5nlz5d9yrqm9255n",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/ba57d5a29b4e0f2085917010380ef3ddc3cf380f.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/af958e8057f345ee1aca714c1247ef3ba1c15f5e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-test-runner": {
@@ -64,11 +64,11 @@
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
-        "repo": "nixpkgs-channels",
-        "rev": "4762fba469e2baa82f983b262e2c06ac2fdaae67",
-        "sha256": "1sidky93vc2bpnwb8avqlym1p70h2szhkfiam549377v9r5ld2r1",
+        "repo": "nixpkgs",
+        "rev": "536fe36e23ab0fc8b7f35c24603422eee9fc17a2",
+        "sha256": "040j2bv45vsa106gblphzgjx2zq90c8mh2iy1ig9xly7xsw15681",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/4762fba469e2baa82f983b262e2c06ac2fdaae67.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/536fe36e23ab0fc8b7f35c24603422eee9fc17a2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-mozilla": {


### PR DESCRIPTION
Please merge #162 first. It contains a test fix.

It seems that [NixOS/nixpkgs-channels is no longer maintained](https://discourse.nixos.org/t/github-com-nixos-nixpkgs-channels-deprecated/9455).
This PR makes `nixpkgs` follow `NixOS/nixpkgs` instead and updated it to the latest release.
I also updated `niv` because it cannot be built otherwise.