### PR TITLE
WIP: add support for veloren in tools.nix

### DIFF
--- a/crate2nix/src/config.rs
+++ b/crate2nix/src/config.rs
@@ -105,7 +105,7 @@ pub enum Source {
         /// The revision hash.
         rev: String,
         /// The sha256 of the fetched result.
-        sha256: String,
+        sha256: Option<String>,
     },
     /// Get the source from a nix expression.
     Nix {
@@ -187,7 +187,7 @@ impl Display for Source {
                 version,
                 sha256,
             } => write!(f, "{} {} from crates.io: {}", name, version, sha256),
-            Source::Git { url, rev, sha256 } => write!(f, "{}#{} via git: {}", url, rev, sha256),
+            Source::Git { url, rev, sha256 } => write!(f, "{}#{} via git: {:?}", url, rev, sha256),
             Source::Nix { file, attr: None } => write!(f, "{}", file),
             Source::Nix {
                 file,

--- a/crate2nix/src/resolve.rs
+++ b/crate2nix/src/resolve.rs
@@ -375,7 +375,7 @@ impl From<crate::config::Source> for ResolvedSource {
                 url,
                 rev,
                 r#ref: None,
-                sha256: Some(sha256),
+                sha256: sha256,
             }),
             crate::config::Source::CratesIo {
                 name,

--- a/crate2nix/src/sources.rs
+++ b/crate2nix/src/sources.rs
@@ -46,7 +46,7 @@ pub fn git_io_source(url: Url, rev: String) -> Result<config::Source, Error> {
     let sha256 = prefetchable.prefetch()?;
     eprintln!("done.");
 
-    Ok(config::Source::Git { url, rev, sha256 })
+    Ok(config::Source::Git { url, rev, sha256: Some(sha256) })
 }
 
 /// Operations on assmebling out-of-tree sources via nix.

--- a/tools.nix
+++ b/tools.nix
@@ -351,14 +351,30 @@ rec {
                 inherit sha256;
                 inherit (parsed) url rev;
               };
+              
+              rootCargo = builtins.fromTOML (builtins.readFile "${src}/Cargo.toml");
+              isWorkspace = rootCargo ? "workspace";
+              isPackage = rootCargo ? "package";
+              containedCrates = rootCargo.workspace.members ++ (if isPackage then ["."] else []);
+
+              getCrateNameFromPath = path: let 
+                cargoTomlCrate = builtins.fromTOML (builtins.readFile "${src}/${path}/Cargo.toml");
+              in
+                cargoTomlCrate.package.name;
+
+              pathToExtract = if isWorkspace then
+                builtins.head (builtins.filter (to_filter:
+                  (getCrateNameFromPath to_filter) == name
+                ) containedCrates)
+              else
+                ".";
             in
             pkgs.runCommand (lib.removeSuffix ".tar.gz" src.name) { }
               ''
                 mkdir -p $out
-                cp -apR ${src}/* $out
+                cp -apR ${src}/${pathToExtract}/* $out
                 echo '{"package":null,"files":{}}' > $out/.cargo-checksum.json
               '';
-
         };
       };
   };


### PR DESCRIPTION
This is my WIP work to be able to automatically generate the Cargo.nix for veloren via the tools.nix. The following change were made:

- allow fetching workspace git depencies
- allow to download git dependancies without an sha256 (that was work I did a long time ago, and don't remember exactly how it work, but it does)

What remain to do:

- figure why num-literal is compiled without num-bigint, so failing the compilation of num that expect num-literal to be compiled with num-bigint (if you can help with that. That seems to be an issue with dynamic feature resolution).