### PR TITLE
treewide: stdenv.lib -> lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ let generatedBuild = callPackage ./crate2nix/Cargo.nix {
     defaultCrateOverrides = pkgs.defaultCrateOverrides // {
       cssparser-macros = attrs: {
         buildInputs =
-          stdenv.lib.optionals
+          lib.optionals
             stdenv.isDarwin
             [ darwin.apple_sdk.frameworks.Security ];
       };

--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -2460,7 +2460,7 @@ rec {
                       crateConfig.sha256;
                   }
                 );
-                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${stdenv.lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
+                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
                 inherit features dependencies buildDependencies crateRenames release;
               }
             );

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -330,7 +330,7 @@ rec {
                       crateConfig.sha256;
                   }
                 );
-                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${stdenv.lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
+                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
                 inherit features dependencies buildDependencies crateRenames release;
               }
             );

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ let
         dontFixup = !release;
       };
       cssparser-macros = attrs: assert builtins.trace "cssparser" true;{
-        buildInputs = stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+        buildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
       };
     };
   };

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -439,7 +439,7 @@ rec {
                       crateConfig.sha256;
                   }
                 );
-                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${stdenv.lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
+                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
                 inherit features dependencies buildDependencies crateRenames release;
               }
             );

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1612,7 +1612,7 @@ rec {
                       crateConfig.sha256;
                   }
                 );
-                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${stdenv.lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
+                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
                 inherit features dependencies buildDependencies crateRenames release;
               }
             );

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -791,7 +791,7 @@ rec {
                       crateConfig.sha256;
                   }
                 );
-                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${stdenv.lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
+                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
                 inherit features dependencies buildDependencies crateRenames release;
               }
             );

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -458,7 +458,7 @@ rec {
                       crateConfig.sha256;
                   }
                 );
-                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${stdenv.lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
+                extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
                 inherit features dependencies buildDependencies crateRenames release;
               }
             );


### PR DESCRIPTION
stdenv.lib is a deprecated alias to lib.

---

Closes https://github.com/kolloch/crate2nix/issues/169.