### PR TITLE
document cross support

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -8,7 +8,7 @@
 , lib ? pkgs.lib
 , stdenv ? pkgs.stdenv
 , buildRustCrateForPkgs ? if buildRustCrate != null
-    then lib.warn "`buildRustCrate` is deprecated, use `buildRustCrateForPkgs` instead" (_: buildRustCrate)
+    then lib.warn "crate2nix: Passing `buildRustCrate` as argument to Cargo.nix is deprecated. If you don't customize `buildRustCrate`, replace `callPackage ./Cargo.nix {}` by `import ./Cargo.nix { inherit pkgs; }`, and if you need to customize `buildRustCrate`, use `buildRustCrateForPkgs` instead." (_: buildRustCrate)
     else pkgs: pkgs.buildRustCrate
   # Deprecated
 , buildRustCrate ? null

--- a/crate2nix/templates/Cargo.nix.tera
+++ b/crate2nix/templates/Cargo.nix.tera
@@ -10,7 +10,7 @@
 , lib ? pkgs.lib
 , stdenv ? pkgs.stdenv
 , buildRustCrateForPkgs ? if buildRustCrate != null
-    then lib.warn "`buildRustCrate` is deprecated, use `buildRustCrateForPkgs` instead" (_: buildRustCrate)
+    then lib.warn "crate2nix: Passing `buildRustCrate` as argument to Cargo.nix is deprecated. If you don't customize `buildRustCrate`, replace `callPackage ./Cargo.nix {}` by `import ./Cargo.nix { inherit pkgs; }`, and if you need to customize `buildRustCrate`, use `buildRustCrateForPkgs` instead." (_: buildRustCrate)
     else pkgs: pkgs.buildRustCrate
   # Deprecated
 , buildRustCrate ? null

--- a/default.nix
+++ b/default.nix
@@ -5,14 +5,13 @@
 , cargo ? pkgs.cargo
 , nix ? pkgs.nix
 , makeWrapper ? pkgs.makeWrapper
-, callPackage ? pkgs.callPackage
 , darwin ? pkgs.darwin
 , stdenv ? pkgs.stdenv
 , defaultCrateOverrides ? pkgs.defaultCrateOverrides
 , release ? true
 }:
 let
-  cargoNix = callPackage ./crate2nix/Cargo.nix { inherit release; };
+  cargoNix = import ./crate2nix/Cargo.nix { inherit pkgs release; };
   withoutTemplates = name: type:
     let
       baseName = builtins.baseNameOf (builtins.toString name);

--- a/nix/dependencies.nix
+++ b/nix/dependencies.nix
@@ -31,10 +31,18 @@
 
     cargoRelease =
       let
-        cargoNix = tools.appliedCargoNix rec {
+        cargoNixSource = tools.generatedCargoNix rec {
           name = "cargo-release";
           src = sources."${name}";
         };
+        buildRustCrateForPkgs = pkgs: pkgs.buildRustCrate.override {
+          defaultCrateOverrides = pkgs.defaultCrateOverrides // {
+            cargo-release = { buildInputs ? [ ], ... }: {
+              buildInputs = buildInputs ++ [ pkgs.openssl ];
+            };
+          };
+        };
+        cargoNix = import cargoNixSource { inherit pkgs buildRustCrateForPkgs; };
       in
       cargoNix.rootCrate.build;
   };

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -8,7 +8,7 @@
 , lib ? pkgs.lib
 , stdenv ? pkgs.stdenv
 , buildRustCrateForPkgs ? if buildRustCrate != null
-    then lib.warn "`buildRustCrate` is deprecated, use `buildRustCrateForPkgs` instead" (_: buildRustCrate)
+    then lib.warn "crate2nix: Passing `buildRustCrate` as argument to Cargo.nix is deprecated. If you don't customize `buildRustCrate`, replace `callPackage ./Cargo.nix {}` by `import ./Cargo.nix { inherit pkgs; }`, and if you need to customize `buildRustCrate`, use `buildRustCrateForPkgs` instead." (_: buildRustCrate)
     else pkgs: pkgs.buildRustCrate
   # Deprecated
 , buildRustCrate ? null

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -8,7 +8,7 @@
 , lib ? pkgs.lib
 , stdenv ? pkgs.stdenv
 , buildRustCrateForPkgs ? if buildRustCrate != null
-    then lib.warn "`buildRustCrate` is deprecated, use `buildRustCrateForPkgs` instead" (_: buildRustCrate)
+    then lib.warn "crate2nix: Passing `buildRustCrate` as argument to Cargo.nix is deprecated. If you don't customize `buildRustCrate`, replace `callPackage ./Cargo.nix {}` by `import ./Cargo.nix { inherit pkgs; }`, and if you need to customize `buildRustCrate`, use `buildRustCrateForPkgs` instead." (_: buildRustCrate)
     else pkgs: pkgs.buildRustCrate
   # Deprecated
 , buildRustCrate ? null

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -8,7 +8,7 @@
 , lib ? pkgs.lib
 , stdenv ? pkgs.stdenv
 , buildRustCrateForPkgs ? if buildRustCrate != null
-    then lib.warn "`buildRustCrate` is deprecated, use `buildRustCrateForPkgs` instead" (_: buildRustCrate)
+    then lib.warn "crate2nix: Passing `buildRustCrate` as argument to Cargo.nix is deprecated. If you don't customize `buildRustCrate`, replace `callPackage ./Cargo.nix {}` by `import ./Cargo.nix { inherit pkgs; }`, and if you need to customize `buildRustCrate`, use `buildRustCrateForPkgs` instead." (_: buildRustCrate)
     else pkgs: pkgs.buildRustCrate
   # Deprecated
 , buildRustCrate ? null

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -8,7 +8,7 @@
 , lib ? pkgs.lib
 , stdenv ? pkgs.stdenv
 , buildRustCrateForPkgs ? if buildRustCrate != null
-    then lib.warn "`buildRustCrate` is deprecated, use `buildRustCrateForPkgs` instead" (_: buildRustCrate)
+    then lib.warn "crate2nix: Passing `buildRustCrate` as argument to Cargo.nix is deprecated. If you don't customize `buildRustCrate`, replace `callPackage ./Cargo.nix {}` by `import ./Cargo.nix { inherit pkgs; }`, and if you need to customize `buildRustCrate`, use `buildRustCrateForPkgs` instead." (_: buildRustCrate)
     else pkgs: pkgs.buildRustCrate
   # Deprecated
 , buildRustCrate ? null

--- a/sample_projects/with_problematic_crates/default.nix
+++ b/sample_projects/with_problematic_crates/default.nix
@@ -4,7 +4,8 @@
 , generatedCargoNix
 }:
 let
-  generatedBuild = pkgs.callPackage generatedCargoNix {
+  generatedBuild = import generatedCargoNix {
+    inherit pkgs;
     defaultCrateOverrides = pkgs.defaultCrateOverrides // {
       pest_generator = attrs: {
         buildInputs =

--- a/tools.nix
+++ b/tools.nix
@@ -11,7 +11,7 @@
 , strictDeprecation ? true
 }:
 let
-  cargoNix = pkgs.callPackage ./crate2nix/Cargo.nix { inherit strictDeprecation; };
+  cargoNix = import ./crate2nix/Cargo.nix { inherit pkgs strictDeprecation; };
   crate2nix = cargoNix.rootCrate.build;
 in
 rec {
@@ -125,7 +125,7 @@ rec {
   # src: the source that is needed to build the crate, usually the crate/workspace root directory
   # cargoToml: Path to the Cargo.toml file relative to src, "Cargo.toml" by default.
   appliedCargoNix = { cargoToml ? "Cargo.toml", ... } @ args:
-    pkgs.callPackage (generatedCargoNix args) { };
+    import (generatedCargoNix args) { inherit pkgs; };
 
   generate =
     cargoNix.internal.deprecationWarning


### PR DESCRIPTION
fix readme to not recommend non-cross-friendly constructs that use
deprecrated buildRustCrate argument to Cargo.nix
improve warning
fix this warning in default.nix

Source: https://github.com/kolloch/crate2nix/pull/160/files#diff-381a73e3c364568cfbd7c56e32e1db595235606948c51c06f04ff99d75aec589

cc @Ericson2314 

Motivation: this warning mentions buildRustCrate but in nix-du's nix files there is no occurence of buildRustCrate in manually written files. It took me really long to understand why the warning was fired.