### PR TITLE
Adds optional dependencies to features when they are enabled indirectly

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -2596,10 +2596,11 @@ rec {
       let
         crateConfig = crateConfigs."${packageId}" or (builtins.throw "Package not found: ${packageId}");
         expandedFeatures = expandFeatures (crateConfig.features or { }) features;
+        enabledFeatures = enableFeatures (crateConfig.dependencies or [ ]) expandedFeatures;
         depWithResolvedFeatures = dependency:
           let
             packageId = dependency.packageId;
-            features = dependencyFeatures expandedFeatures dependency;
+            features = dependencyFeatures enabledFeatures dependency;
           in
           { inherit packageId features; };
         resolveDependencies = cache: path: dependencies:
@@ -2608,7 +2609,7 @@ rec {
           let
             enabledDependencies = filterEnabledDependencies {
               inherit dependencies target;
-              features = expandedFeatures;
+              features = enabledFeatures;
             };
             directDependencies = map depWithResolvedFeatures enabledDependencies;
             foldOverCache = op: lib.foldl op cache directDependencies;
@@ -2632,7 +2633,7 @@ rec {
         cacheWithSelf =
           let
             cacheFeatures = featuresByPackageId.${packageId} or [ ];
-            combinedFeatures = sortedUnique (cacheFeatures ++ expandedFeatures);
+            combinedFeatures = sortedUnique (cacheFeatures ++ enabledFeatures);
           in
           featuresByPackageId // {
             "${packageId}" = combinedFeatures;
@@ -2699,6 +2700,28 @@ rec {
       outFeatures = lib.concatMap expandFeature inputFeatures;
     in
     sortedUnique outFeatures;
+
+  /* This function adds optional dependencies as features if they are enabled
+     indirectly by dependency features. This function mimics Cargo's behavior
+     described in a note at:
+     https://doc.rust-lang.org/nightly/cargo/reference/features.html#dependency-features
+  */
+  enableFeatures = dependencies: features:
+    assert (builtins.isList features);
+    assert (builtins.isList dependencies);
+    let
+      additionalFeatures = lib.concatMap
+        (
+          dependency:
+            assert (builtins.isAttrs dependency);
+            let
+              enabled = builtins.any (doesFeatureEnableDependency dependency) features;
+            in
+            if (dependency.optional or false) && enabled then [ dependency.name ] else [ ]
+        )
+        dependencies;
+    in
+    sortedUnique (features ++ additionalFeatures);
 
   /*
      Returns the actual features for the given dependency.

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -466,10 +466,11 @@ rec {
       let
         crateConfig = crateConfigs."${packageId}" or (builtins.throw "Package not found: ${packageId}");
         expandedFeatures = expandFeatures (crateConfig.features or { }) features;
+        enabledFeatures = enableFeatures (crateConfig.dependencies or [ ]) expandedFeatures;
         depWithResolvedFeatures = dependency:
           let
             packageId = dependency.packageId;
-            features = dependencyFeatures expandedFeatures dependency;
+            features = dependencyFeatures enabledFeatures dependency;
           in
           { inherit packageId features; };
         resolveDependencies = cache: path: dependencies:
@@ -478,7 +479,7 @@ rec {
           let
             enabledDependencies = filterEnabledDependencies {
               inherit dependencies target;
-              features = expandedFeatures;
+              features = enabledFeatures;
             };
             directDependencies = map depWithResolvedFeatures enabledDependencies;
             foldOverCache = op: lib.foldl op cache directDependencies;
@@ -502,7 +503,7 @@ rec {
         cacheWithSelf =
           let
             cacheFeatures = featuresByPackageId.${packageId} or [ ];
-            combinedFeatures = sortedUnique (cacheFeatures ++ expandedFeatures);
+            combinedFeatures = sortedUnique (cacheFeatures ++ enabledFeatures);
           in
           featuresByPackageId // {
             "${packageId}" = combinedFeatures;
@@ -569,6 +570,28 @@ rec {
       outFeatures = lib.concatMap expandFeature inputFeatures;
     in
     sortedUnique outFeatures;
+
+  /* This function adds optional dependencies as features if they are enabled
+     indirectly by dependency features. This function mimics Cargo's behavior
+     described in a note at:
+     https://doc.rust-lang.org/nightly/cargo/reference/features.html#dependency-features
+  */
+  enableFeatures = dependencies: features:
+    assert (builtins.isList features);
+    assert (builtins.isList dependencies);
+    let
+      additionalFeatures = lib.concatMap
+        (
+          dependency:
+            assert (builtins.isAttrs dependency);
+            let
+              enabled = builtins.any (doesFeatureEnableDependency dependency) features;
+            in
+            if (dependency.optional or false) && enabled then [ dependency.name ] else [ ]
+        )
+        dependencies;
+    in
+    sortedUnique (features ++ additionalFeatures);
 
   /*
      Returns the actual features for the given dependency.

--- a/crate2nix/templates/nix/crate2nix/tests/packageFeatures.nix
+++ b/crate2nix/templates/nix/crate2nix/tests/packageFeatures.nix
@@ -98,7 +98,7 @@ in
   testNumDependencies = {
     expr = packageFeatures "pkg_num" [ "default" ];
     expected = {
-      "pkg_num" = [ "default" "num-bigint/std" "std" ];
+      "pkg_num" = [ "default" "num-bigint" "num-bigint/std" "std" ];
       "pkg_num_bigint" = [ "std" ];
     };
   };
@@ -107,7 +107,7 @@ in
     expr = packageFeatures "pkg_numtest" [ "default" ];
     expected = {
       "pkg_numtest" = [ "default" ];
-      "pkg_num" = [ "default" "num-bigint/std" "std" ];
+      "pkg_num" = [ "default" "num-bigint" "num-bigint/std" "std" ];
       "pkg_num_bigint" = [ "std" ];
     };
   };

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -575,10 +575,11 @@ rec {
       let
         crateConfig = crateConfigs."${packageId}" or (builtins.throw "Package not found: ${packageId}");
         expandedFeatures = expandFeatures (crateConfig.features or { }) features;
+        enabledFeatures = enableFeatures (crateConfig.dependencies or [ ]) expandedFeatures;
         depWithResolvedFeatures = dependency:
           let
             packageId = dependency.packageId;
-            features = dependencyFeatures expandedFeatures dependency;
+            features = dependencyFeatures enabledFeatures dependency;
           in
           { inherit packageId features; };
         resolveDependencies = cache: path: dependencies:
@@ -587,7 +588,7 @@ rec {
           let
             enabledDependencies = filterEnabledDependencies {
               inherit dependencies target;
-              features = expandedFeatures;
+              features = enabledFeatures;
             };
             directDependencies = map depWithResolvedFeatures enabledDependencies;
             foldOverCache = op: lib.foldl op cache directDependencies;
@@ -611,7 +612,7 @@ rec {
         cacheWithSelf =
           let
             cacheFeatures = featuresByPackageId.${packageId} or [ ];
-            combinedFeatures = sortedUnique (cacheFeatures ++ expandedFeatures);
+            combinedFeatures = sortedUnique (cacheFeatures ++ enabledFeatures);
           in
           featuresByPackageId // {
             "${packageId}" = combinedFeatures;
@@ -678,6 +679,28 @@ rec {
       outFeatures = lib.concatMap expandFeature inputFeatures;
     in
     sortedUnique outFeatures;
+
+  /* This function adds optional dependencies as features if they are enabled
+     indirectly by dependency features. This function mimics Cargo's behavior
+     described in a note at:
+     https://doc.rust-lang.org/nightly/cargo/reference/features.html#dependency-features
+  */
+  enableFeatures = dependencies: features:
+    assert (builtins.isList features);
+    assert (builtins.isList dependencies);
+    let
+      additionalFeatures = lib.concatMap
+        (
+          dependency:
+            assert (builtins.isAttrs dependency);
+            let
+              enabled = builtins.any (doesFeatureEnableDependency dependency) features;
+            in
+            if (dependency.optional or false) && enabled then [ dependency.name ] else [ ]
+        )
+        dependencies;
+    in
+    sortedUnique (features ++ additionalFeatures);
 
   /*
      Returns the actual features for the given dependency.

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1748,10 +1748,11 @@ rec {
       let
         crateConfig = crateConfigs."${packageId}" or (builtins.throw "Package not found: ${packageId}");
         expandedFeatures = expandFeatures (crateConfig.features or { }) features;
+        enabledFeatures = enableFeatures (crateConfig.dependencies or [ ]) expandedFeatures;
         depWithResolvedFeatures = dependency:
           let
             packageId = dependency.packageId;
-            features = dependencyFeatures expandedFeatures dependency;
+            features = dependencyFeatures enabledFeatures dependency;
           in
           { inherit packageId features; };
         resolveDependencies = cache: path: dependencies:
@@ -1760,7 +1761,7 @@ rec {
           let
             enabledDependencies = filterEnabledDependencies {
               inherit dependencies target;
-              features = expandedFeatures;
+              features = enabledFeatures;
             };
             directDependencies = map depWithResolvedFeatures enabledDependencies;
             foldOverCache = op: lib.foldl op cache directDependencies;
@@ -1784,7 +1785,7 @@ rec {
         cacheWithSelf =
           let
             cacheFeatures = featuresByPackageId.${packageId} or [ ];
-            combinedFeatures = sortedUnique (cacheFeatures ++ expandedFeatures);
+            combinedFeatures = sortedUnique (cacheFeatures ++ enabledFeatures);
           in
           featuresByPackageId // {
             "${packageId}" = combinedFeatures;
@@ -1851,6 +1852,28 @@ rec {
       outFeatures = lib.concatMap expandFeature inputFeatures;
     in
     sortedUnique outFeatures;
+
+  /* This function adds optional dependencies as features if they are enabled
+     indirectly by dependency features. This function mimics Cargo's behavior
+     described in a note at:
+     https://doc.rust-lang.org/nightly/cargo/reference/features.html#dependency-features
+  */
+  enableFeatures = dependencies: features:
+    assert (builtins.isList features);
+    assert (builtins.isList dependencies);
+    let
+      additionalFeatures = lib.concatMap
+        (
+          dependency:
+            assert (builtins.isAttrs dependency);
+            let
+              enabled = builtins.any (doesFeatureEnableDependency dependency) features;
+            in
+            if (dependency.optional or false) && enabled then [ dependency.name ] else [ ]
+        )
+        dependencies;
+    in
+    sortedUnique (features ++ additionalFeatures);
 
   /*
      Returns the actual features for the given dependency.

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -927,10 +927,11 @@ rec {
       let
         crateConfig = crateConfigs."${packageId}" or (builtins.throw "Package not found: ${packageId}");
         expandedFeatures = expandFeatures (crateConfig.features or { }) features;
+        enabledFeatures = enableFeatures (crateConfig.dependencies or [ ]) expandedFeatures;
         depWithResolvedFeatures = dependency:
           let
             packageId = dependency.packageId;
-            features = dependencyFeatures expandedFeatures dependency;
+            features = dependencyFeatures enabledFeatures dependency;
           in
           { inherit packageId features; };
         resolveDependencies = cache: path: dependencies:
@@ -939,7 +940,7 @@ rec {
           let
             enabledDependencies = filterEnabledDependencies {
               inherit dependencies target;
-              features = expandedFeatures;
+              features = enabledFeatures;
             };
             directDependencies = map depWithResolvedFeatures enabledDependencies;
             foldOverCache = op: lib.foldl op cache directDependencies;
@@ -963,7 +964,7 @@ rec {
         cacheWithSelf =
           let
             cacheFeatures = featuresByPackageId.${packageId} or [ ];
-            combinedFeatures = sortedUnique (cacheFeatures ++ expandedFeatures);
+            combinedFeatures = sortedUnique (cacheFeatures ++ enabledFeatures);
           in
           featuresByPackageId // {
             "${packageId}" = combinedFeatures;
@@ -1030,6 +1031,28 @@ rec {
       outFeatures = lib.concatMap expandFeature inputFeatures;
     in
     sortedUnique outFeatures;
+
+  /* This function adds optional dependencies as features if they are enabled
+     indirectly by dependency features. This function mimics Cargo's behavior
+     described in a note at:
+     https://doc.rust-lang.org/nightly/cargo/reference/features.html#dependency-features
+  */
+  enableFeatures = dependencies: features:
+    assert (builtins.isList features);
+    assert (builtins.isList dependencies);
+    let
+      additionalFeatures = lib.concatMap
+        (
+          dependency:
+            assert (builtins.isAttrs dependency);
+            let
+              enabled = builtins.any (doesFeatureEnableDependency dependency) features;
+            in
+            if (dependency.optional or false) && enabled then [ dependency.name ] else [ ]
+        )
+        dependencies;
+    in
+    sortedUnique (features ++ additionalFeatures);
 
   /*
      Returns the actual features for the given dependency.


### PR DESCRIPTION
When Cargo sees a dependency feature `opt_crate/feat` for an optional dependency `opt_crate`,
it implicitly adds `opt_crate` to the feature set for the current crate.
For example, `num-rational` crate relies on this behavior for importing `num-bigint`, which is optional.
This patch lets crate2nix mimic this behavior.

Main changes are in [crate2nix/templates/nix/crate2nix/default.nix](https://github.com/kolloch/crate2nix/compare/master...pandaman64:add-optional-dep-as-feature?expand=1#diff-573bf3b71d0d8bf3ff7c415529cde20e362cf673c32b75d4fe170ed880c39655)
I also modified test cases([crate2nix/templates/nix/crate2nix/tests/packageFeatures.nix](https://github.com/kolloch/crate2nix/compare/master...pandaman64:add-optional-dep-as-feature?expand=1#diff-ae3d76bc49319d02ff1dd589344d2b695cd301cdee52cc85250ab9c4eb91ecc6)) so that they match what Cargo does.

Closes #146, #182.