### PR TITLE
Allow arbitrary commands before and after tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,10 +279,10 @@ NixOS that crate2nix uses.
 
 ## Running rust tests
 
-There is some experimental support for running tests of your rust crates. All
-of the crates in the workspace will have their tests executed. When enabling
-test execution (`runTests = true;`), failing tests will make the whole build
-fail.
+There is some experimental support for running tests of your rust crates. All of
+the crates in the workspace will have their tests executed. When enabling test
+execution (`runTests = true;`), failing tests will make the whole build fail
+unless you explicitly disable this via test hooks: see the section below.
 
 ```nix
       let cargo_nix = import ./Cargo.nix { inherit pkgs; };
@@ -296,6 +296,20 @@ fail.
 `testInputs` is optional and allows passing inputs to the test execution that
 should be in scope. Defaults to an empty list and is ignored when `runTests`
 equals `false`.
+
+### Custom pre/post test hooks
+
+There are `testPreRun` and `testPostRun` attributes available for the crates
+that are being tested. These are ran directly before and after the actual test
+command. Some example use-cases include:
+
+* setting some environment variable that's needed for the test
+
+* setting (and then unsetting) the bash `set +e` option to not fail the
+  derivation build even if a test fails. This is quite useful if your tests are
+  not flaky and you want to cache failures.
+
+Arbitrary `bash` expressions are accepted.
 
 ## FAQ
 

--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -2226,9 +2226,11 @@ rec {
      testCrateFlags: list of flags to pass to the test exectuable
      testInputs: list of packages that should be available during test execution
   */
-  crateWithTest = { crate, testCrate, testCrateFlags, testInputs }:
+  crateWithTest = { crate, testCrate, testCrateFlags, testInputs, testPreRun, testPostRun }:
     assert builtins.typeOf testCrateFlags == "list";
     assert builtins.typeOf testInputs == "list";
+    assert builtins.typeOf testPreRun == "string";
+    assert builtins.typeOf testPostRun == "string";
     let
       # override the `crate` so that it will build and execute tests instead of
       # building the actual lib and bin targets We just have to pass `--test`
@@ -2242,6 +2244,15 @@ rec {
                 buildTests = true;
               }
             );
+          # If the user hasn't set any pre/post commands, we don't want to
+          # insert empty lines. This means that any existing users of crate2nix
+          # don't get a spurious rebuild unless they set these explicitly.
+          testCommand = pkgs.lib.concatStringsSep "\n"
+            (pkgs.lib.filter (s: s != "") [
+              testPreRun
+              "$f $testCrateFlags 2>&1 | tee -a $out"
+              testPostRun
+            ]);
         in
         pkgs.runCommand "run-tests-${testCrate.name}"
           {
@@ -2275,7 +2286,7 @@ rec {
           for file in ${drv}/tests/*; do
             f=$testRoot/$(basename $file)-$hash
             cp $file $f
-            $f $testCrateFlags 2>&1 | tee -a $out
+            ${testCommand}
           done
         '';
     in
@@ -2299,6 +2310,10 @@ rec {
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
+      # Any command to run immediatelly before a test is executed.
+    , testPreRun ? ""
+      # Any command run immediatelly after a test is executed.
+    , testPostRun ? ""
     }:
     lib.makeOverridable
       (
@@ -2307,6 +2322,8 @@ rec {
         , runTests
         , testCrateFlags
         , testInputs
+        , testPreRun
+        , testPostRun
         }:
         let
           buildRustCrateForPkgsFuncOverriden =
@@ -2339,13 +2356,13 @@ rec {
                 {
                   crate = drv;
                   testCrate = testDrv;
-                  inherit testCrateFlags testInputs;
+                  inherit testCrateFlags testInputs testPreRun testPostRun;
                 }
             else drv;
         in
         derivation
       )
-      { inherit features crateOverrides runTests testCrateFlags testInputs; };
+      { inherit features crateOverrides runTests testCrateFlags testInputs testPreRun testPostRun; };
 
   /* Returns an attr set with packageId mapped to the result of buildRustCrateForPkgsFunc
      for the corresponding crate.

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -205,9 +205,11 @@ rec {
      testCrateFlags: list of flags to pass to the test exectuable
      testInputs: list of packages that should be available during test execution
   */
-  crateWithTest = { crate, testCrate, testCrateFlags, testInputs }:
+  crateWithTest = { crate, testCrate, testCrateFlags, testInputs, testPreRun, testPostRun }:
     assert builtins.typeOf testCrateFlags == "list";
     assert builtins.typeOf testInputs == "list";
+    assert builtins.typeOf testPreRun == "string";
+    assert builtins.typeOf testPostRun == "string";
     let
       # override the `crate` so that it will build and execute tests instead of
       # building the actual lib and bin targets We just have to pass `--test`
@@ -221,6 +223,15 @@ rec {
                 buildTests = true;
               }
             );
+          # If the user hasn't set any pre/post commands, we don't want to
+          # insert empty lines. This means that any existing users of crate2nix
+          # don't get a spurious rebuild unless they set these explicitly.
+          testCommand = pkgs.lib.concatStringsSep "\n"
+            (pkgs.lib.filter (s: s != "") [
+              testPreRun
+              "$f $testCrateFlags 2>&1 | tee -a $out"
+              testPostRun
+            ]);
         in
         pkgs.runCommand "run-tests-${testCrate.name}"
           {
@@ -254,7 +265,7 @@ rec {
           for file in ${drv}/tests/*; do
             f=$testRoot/$(basename $file)-$hash
             cp $file $f
-            $f $testCrateFlags 2>&1 | tee -a $out
+            ${testCommand}
           done
         '';
     in
@@ -278,6 +289,10 @@ rec {
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
+      # Any command to run immediatelly before a test is executed.
+    , testPreRun ? ""
+      # Any command run immediatelly after a test is executed.
+    , testPostRun ? ""
     }:
     lib.makeOverridable
       (
@@ -286,6 +301,8 @@ rec {
         , runTests
         , testCrateFlags
         , testInputs
+        , testPreRun
+        , testPostRun
         }:
         let
           buildRustCrateForPkgsFuncOverriden =
@@ -318,13 +335,13 @@ rec {
                 {
                   crate = drv;
                   testCrate = testDrv;
-                  inherit testCrateFlags testInputs;
+                  inherit testCrateFlags testInputs testPreRun testPostRun;
                 }
             else drv;
         in
         derivation
       )
-      { inherit features crateOverrides runTests testCrateFlags testInputs; };
+      { inherit features crateOverrides runTests testCrateFlags testInputs testPreRun testPostRun; };
 
   /* Returns an attr set with packageId mapped to the result of buildRustCrateForPkgsFunc
      for the corresponding crate.

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1378,9 +1378,11 @@ rec {
      testCrateFlags: list of flags to pass to the test exectuable
      testInputs: list of packages that should be available during test execution
   */
-  crateWithTest = { crate, testCrate, testCrateFlags, testInputs }:
+  crateWithTest = { crate, testCrate, testCrateFlags, testInputs, testPreRun, testPostRun }:
     assert builtins.typeOf testCrateFlags == "list";
     assert builtins.typeOf testInputs == "list";
+    assert builtins.typeOf testPreRun == "string";
+    assert builtins.typeOf testPostRun == "string";
     let
       # override the `crate` so that it will build and execute tests instead of
       # building the actual lib and bin targets We just have to pass `--test`
@@ -1394,6 +1396,15 @@ rec {
                 buildTests = true;
               }
             );
+          # If the user hasn't set any pre/post commands, we don't want to
+          # insert empty lines. This means that any existing users of crate2nix
+          # don't get a spurious rebuild unless they set these explicitly.
+          testCommand = pkgs.lib.concatStringsSep "\n"
+            (pkgs.lib.filter (s: s != "") [
+              testPreRun
+              "$f $testCrateFlags 2>&1 | tee -a $out"
+              testPostRun
+            ]);
         in
         pkgs.runCommand "run-tests-${testCrate.name}"
           {
@@ -1427,7 +1438,7 @@ rec {
           for file in ${drv}/tests/*; do
             f=$testRoot/$(basename $file)-$hash
             cp $file $f
-            $f $testCrateFlags 2>&1 | tee -a $out
+            ${testCommand}
           done
         '';
     in
@@ -1451,6 +1462,10 @@ rec {
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
+      # Any command to run immediatelly before a test is executed.
+    , testPreRun ? ""
+      # Any command run immediatelly after a test is executed.
+    , testPostRun ? ""
     }:
     lib.makeOverridable
       (
@@ -1459,6 +1474,8 @@ rec {
         , runTests
         , testCrateFlags
         , testInputs
+        , testPreRun
+        , testPostRun
         }:
         let
           buildRustCrateForPkgsFuncOverriden =
@@ -1491,13 +1508,13 @@ rec {
                 {
                   crate = drv;
                   testCrate = testDrv;
-                  inherit testCrateFlags testInputs;
+                  inherit testCrateFlags testInputs testPreRun testPostRun;
                 }
             else drv;
         in
         derivation
       )
-      { inherit features crateOverrides runTests testCrateFlags testInputs; };
+      { inherit features crateOverrides runTests testCrateFlags testInputs testPreRun testPostRun; };
 
   /* Returns an attr set with packageId mapped to the result of buildRustCrateForPkgsFunc
      for the corresponding crate.

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -557,9 +557,11 @@ rec {
      testCrateFlags: list of flags to pass to the test exectuable
      testInputs: list of packages that should be available during test execution
   */
-  crateWithTest = { crate, testCrate, testCrateFlags, testInputs }:
+  crateWithTest = { crate, testCrate, testCrateFlags, testInputs, testPreRun, testPostRun }:
     assert builtins.typeOf testCrateFlags == "list";
     assert builtins.typeOf testInputs == "list";
+    assert builtins.typeOf testPreRun == "string";
+    assert builtins.typeOf testPostRun == "string";
     let
       # override the `crate` so that it will build and execute tests instead of
       # building the actual lib and bin targets We just have to pass `--test`
@@ -573,6 +575,15 @@ rec {
                 buildTests = true;
               }
             );
+          # If the user hasn't set any pre/post commands, we don't want to
+          # insert empty lines. This means that any existing users of crate2nix
+          # don't get a spurious rebuild unless they set these explicitly.
+          testCommand = pkgs.lib.concatStringsSep "\n"
+            (pkgs.lib.filter (s: s != "") [
+              testPreRun
+              "$f $testCrateFlags 2>&1 | tee -a $out"
+              testPostRun
+            ]);
         in
         pkgs.runCommand "run-tests-${testCrate.name}"
           {
@@ -606,7 +617,7 @@ rec {
           for file in ${drv}/tests/*; do
             f=$testRoot/$(basename $file)-$hash
             cp $file $f
-            $f $testCrateFlags 2>&1 | tee -a $out
+            ${testCommand}
           done
         '';
     in
@@ -630,6 +641,10 @@ rec {
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
+      # Any command to run immediatelly before a test is executed.
+    , testPreRun ? ""
+      # Any command run immediatelly after a test is executed.
+    , testPostRun ? ""
     }:
     lib.makeOverridable
       (
@@ -638,6 +653,8 @@ rec {
         , runTests
         , testCrateFlags
         , testInputs
+        , testPreRun
+        , testPostRun
         }:
         let
           buildRustCrateForPkgsFuncOverriden =
@@ -670,13 +687,13 @@ rec {
                 {
                   crate = drv;
                   testCrate = testDrv;
-                  inherit testCrateFlags testInputs;
+                  inherit testCrateFlags testInputs testPreRun testPostRun;
                 }
             else drv;
         in
         derivation
       )
-      { inherit features crateOverrides runTests testCrateFlags testInputs; };
+      { inherit features crateOverrides runTests testCrateFlags testInputs testPreRun testPostRun; };
 
   /* Returns an attr set with packageId mapped to the result of buildRustCrateForPkgsFunc
      for the corresponding crate.

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -224,9 +224,11 @@ rec {
      testCrateFlags: list of flags to pass to the test exectuable
      testInputs: list of packages that should be available during test execution
   */
-  crateWithTest = { crate, testCrate, testCrateFlags, testInputs }:
+  crateWithTest = { crate, testCrate, testCrateFlags, testInputs, testPreRun, testPostRun }:
     assert builtins.typeOf testCrateFlags == "list";
     assert builtins.typeOf testInputs == "list";
+    assert builtins.typeOf testPreRun == "string";
+    assert builtins.typeOf testPostRun == "string";
     let
       # override the `crate` so that it will build and execute tests instead of
       # building the actual lib and bin targets We just have to pass `--test`
@@ -240,6 +242,15 @@ rec {
                 buildTests = true;
               }
             );
+          # If the user hasn't set any pre/post commands, we don't want to
+          # insert empty lines. This means that any existing users of crate2nix
+          # don't get a spurious rebuild unless they set these explicitly.
+          testCommand = pkgs.lib.concatStringsSep "\n"
+            (pkgs.lib.filter (s: s != "") [
+              testPreRun
+              "$f $testCrateFlags 2>&1 | tee -a $out"
+              testPostRun
+            ]);
         in
         pkgs.runCommand "run-tests-${testCrate.name}"
           {
@@ -273,7 +284,7 @@ rec {
           for file in ${drv}/tests/*; do
             f=$testRoot/$(basename $file)-$hash
             cp $file $f
-            $f $testCrateFlags 2>&1 | tee -a $out
+            ${testCommand}
           done
         '';
     in
@@ -297,6 +308,10 @@ rec {
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
+      # Any command to run immediatelly before a test is executed.
+    , testPreRun ? ""
+      # Any command run immediatelly after a test is executed.
+    , testPostRun ? ""
     }:
     lib.makeOverridable
       (
@@ -305,6 +320,8 @@ rec {
         , runTests
         , testCrateFlags
         , testInputs
+        , testPreRun
+        , testPostRun
         }:
         let
           buildRustCrateForPkgsFuncOverriden =
@@ -337,13 +354,13 @@ rec {
                 {
                   crate = drv;
                   testCrate = testDrv;
-                  inherit testCrateFlags testInputs;
+                  inherit testCrateFlags testInputs testPreRun testPostRun;
                 }
             else drv;
         in
         derivation
       )
-      { inherit features crateOverrides runTests testCrateFlags testInputs; };
+      { inherit features crateOverrides runTests testCrateFlags testInputs testPreRun testPostRun; };
 
   /* Returns an attr set with packageId mapped to the result of buildRustCrateForPkgsFunc
      for the corresponding crate.


### PR DESCRIPTION
An immediate use-case is to inject any environment variables that the
test may be relying on, such as location of some external files
or overriding some behaviour.

Another, perhaps more cliche use-case is for unsetting the `-e` bash
flag: this will allow us to capture output of failing tests without
giving up on expression itself. In this way, it fixes #191.