### PR TITLE
nix-prefetch-git should be available in the shell

### DIFF
--- a/nix/dependencies.nix
+++ b/nix/dependencies.nix
@@ -17,6 +17,7 @@
       git
       utillinux
       cacert
+      nix-prefetch-git
       ;
 
     nixTest =


### PR DESCRIPTION
Otherwise `cargo run` won't find everything it needs.