### PR TITLE
Fix HTTPS url to github repo

### DIFF
--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -238,7 +238,7 @@ rec {
         edition = "2018";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/diwic/dbus-rs/";
+          url = "https://github.com/diwic/dbus-rs.git";
           rev = "b079366e27da1b9c2869f065fbb6004138e439c2";
           sha256 = "0lbp76vvi0cw57lxhfqmz22qd5l61w3rh8g58hhmwi8wcr9qmiiw";
         };
@@ -265,7 +265,7 @@ rec {
         crateBin = [];
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/diwic/dbus-rs/";
+          url = "https://github.com/diwic/dbus-rs.git";
           rev = "b079366e27da1b9c2869f065fbb6004138e439c2";
           sha256 = "0lbp76vvi0cw57lxhfqmz22qd5l61w3rh8g58hhmwi8wcr9qmiiw";
         };
@@ -309,7 +309,7 @@ rec {
         edition = "2015";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/diwic/dbus-rs/";
+          url = "https://github.com/diwic/dbus-rs.git";
           rev = "b079366e27da1b9c2869f065fbb6004138e439c2";
           sha256 = "0lbp76vvi0cw57lxhfqmz22qd5l61w3rh8g58hhmwi8wcr9qmiiw";
         };

--- a/sample_projects/codegen/Cargo.toml
+++ b/sample_projects/codegen/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-dbus = { git = "https://github.com/diwic/dbus-rs/" }
+dbus = { git = "https://github.com/diwic/dbus-rs.git" }
 
 [build-dependencies]
 dbus-codegen = { git = "https://github.com/diwic/dbus-rs" }


### PR DESCRIPTION
Github seems to no longer like trailing slashes in repo names with
https, so end with `.git` instead like the others, and as github's
"clone" button recommends.