### PR TITLE
refactor(github/workflows/niv-updater): run once a week

### DIFF
--- a/.github/workflows/niv-update.yml
+++ b/.github/workflows/niv-update.yml
@@ -3,7 +3,7 @@ name: niv-update
 on:
   push:
   schedule:
-    - cron: '17 10-17 * * *'
+    - cron: '0 0 * * 1'
 
 jobs:
   niv-update:


### PR DESCRIPTION
The current updater workflow is very hyper, polluting the commit logs with a
flood of update commits.

This changes it to only run once a week, which hopefully is more than enough.
