### PR TITLE
Fix broken IFD build with Nix 2.4

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -454,7 +454,7 @@ rec {
         ];
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder "2.4" builtins.nixVersion)
+        src = if (lib.versionOlder "2.4pre20211007" builtins.nixVersion)
           then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
           else ./.;
         authors = [

--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -452,7 +452,11 @@ rec {
         crateBin = [
           { name = "crate2nix"; path = "src/main.rs"; }
         ];
-        src = lib.cleanSourceWith { filter = sourceFilter;  src = ./.; };
+        # We can't filter paths with references in Nix 2.4
+        # See https://github.com/NixOS/nix/issues/5410
+        src = if (lib.versionOlder builtins.nixVersion "2.4")
+          then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
+          else ./.;
         authors = [
           "Peter Kolloch <info@eigenvalue.net>"
         ];

--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -454,7 +454,7 @@ rec {
         ];
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder "2.4pre20211007" builtins.nixVersion)
+        src = if (lib.versionOlder builtins.nixVersion "2.4pre20211007")
           then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
           else ./.;
         authors = [

--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -454,7 +454,7 @@ rec {
         ];
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder builtins.nixVersion "2.4")
+        src = if (lib.versionOlder "2.4" builtins.nixVersion)
           then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
           else ./.;
         authors = [

--- a/crate2nix/templates/Cargo.nix.tera
+++ b/crate2nix/templates/Cargo.nix.tera
@@ -124,7 +124,7 @@ rec {
         {%- elif crate.source.LocalDirectory.path %}
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder "2.4" builtins.nixVersion)
+        src = if (lib.versionOlder builtins.nixVersion "2.4pre20211007")
           then lib.cleanSourceWith { filter = sourceFilter;  src = {{crate.source.LocalDirectory.path | safe}}; }
           else {{crate.source.LocalDirectory.path | safe}};
         {%- elif crate.source.Git %}

--- a/crate2nix/templates/Cargo.nix.tera
+++ b/crate2nix/templates/Cargo.nix.tera
@@ -122,7 +122,11 @@ rec {
         {%- elif crate.source.Nix.file.package %}
         src = pkgs.callPackage {{crate.source.Nix.file.package | safe}} {};
         {%- elif crate.source.LocalDirectory.path %}
-        src = lib.cleanSourceWith { filter = sourceFilter;  src = {{crate.source.LocalDirectory.path | safe}}; };
+        # We can't filter paths with references in Nix 2.4
+        # See https://github.com/NixOS/nix/issues/5410
+        src = if (lib.versionOlder builtins.nixVersion "2.4")
+          then lib.cleanSourceWith { filter = sourceFilter;  src = {{crate.source.LocalDirectory.path | safe}}; }
+          else {{crate.source.LocalDirectory.path | safe}};
         {%- elif crate.source.Git %}
         workspace_member = null;
         src = pkgs.fetchgit {

--- a/crate2nix/templates/Cargo.nix.tera
+++ b/crate2nix/templates/Cargo.nix.tera
@@ -124,7 +124,7 @@ rec {
         {%- elif crate.source.LocalDirectory.path %}
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder builtins.nixVersion "2.4")
+        src = if (lib.versionOlder "2.4" builtins.nixVersion)
           then lib.cleanSourceWith { filter = sourceFilter;  src = {{crate.source.LocalDirectory.path | safe}}; }
           else {{crate.source.LocalDirectory.path | safe}};
         {%- elif crate.source.Git %}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -24,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "crate2nix": {
-        "branch": "master",
+        "branch": "balsoft/fix-broken-ifd",
         "description": "nix build file generator for rust crates",
         "homepage": "",
-        "owner": "kolloch",
+        "owner": "balsoft",
         "repo": "crate2nix",
-        "rev": "a18488a2083c0148c07b874343701fdfec1cd2af",
-        "sha256": "0ygbgwgnnlhm5wpll7vjfxaww7j50faj8qg0nc8jvwmnr9iv2svw",
+        "rev": "c704f6a0a76684ad65f852393480f6777a87f7ff",
+        "sha256": "1bmz1qawih9s97bki5c5zrdjgad26yk6c60r5qh5pn31aybpmhgk",
         "type": "tarball",
-        "url": "https://github.com/kolloch/crate2nix/archive/a18488a2083c0148c07b874343701fdfec1cd2af.tar.gz",
+        "url": "https://github.com/balsoft/crate2nix/archive/c704f6a0a76684ad65f852393480f6777a87f7ff.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-test-runner": {

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -96,7 +96,7 @@ rec {
         ];
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder "2.4" builtins.nixVersion)
+        src = if (lib.versionOlder "2.4pre20211007" builtins.nixVersion)
           then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
           else ./.;
         authors = [

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -94,7 +94,11 @@ rec {
         crateBin = [
           { name = "bin_with_lib_git_dep"; path = "src/main.rs"; }
         ];
-        src = lib.cleanSourceWith { filter = sourceFilter;  src = ./.; };
+        # We can't filter paths with references in Nix 2.4
+        # See https://github.com/NixOS/nix/issues/5410
+        src = if (lib.versionOlder builtins.nixVersion "2.4")
+          then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
+          else ./.;
         authors = [
           "Peter Kolloch <info@eigenvalue.net>"
         ];

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -96,7 +96,7 @@ rec {
         ];
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder "2.4pre20211007" builtins.nixVersion)
+        src = if (lib.versionOlder builtins.nixVersion "2.4pre20211007")
           then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
           else ./.;
         authors = [

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -96,7 +96,7 @@ rec {
         ];
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder builtins.nixVersion "2.4")
+        src = if (lib.versionOlder "2.4" builtins.nixVersion)
           then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
           else ./.;
         authors = [

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -224,7 +224,11 @@ rec {
         crateBin = [
           { name = "bin_with_git_submodule_dep"; path = "src/main.rs"; }
         ];
-        src = lib.cleanSourceWith { filter = sourceFilter;  src = ./.; };
+        # We can't filter paths with references in Nix 2.4
+        # See https://github.com/NixOS/nix/issues/5410
+        src = if (lib.versionOlder builtins.nixVersion "2.4")
+          then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
+          else ./.;
         authors = [
           "Phillip Cloud <cloud@standard.ai>"
         ];

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -226,7 +226,7 @@ rec {
         ];
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder "2.4pre20211007" builtins.nixVersion)
+        src = if (lib.versionOlder builtins.nixVersion "2.4pre20211007")
           then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
           else ./.;
         authors = [

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -226,7 +226,7 @@ rec {
         ];
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder "2.4" builtins.nixVersion)
+        src = if (lib.versionOlder "2.4pre20211007" builtins.nixVersion)
           then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
           else ./.;
         authors = [

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -226,7 +226,7 @@ rec {
         ];
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder builtins.nixVersion "2.4")
+        src = if (lib.versionOlder "2.4" builtins.nixVersion)
           then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
           else ./.;
         authors = [

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -214,7 +214,11 @@ rec {
         crateBin = [
           { name = "codegen"; path = "src/main.rs"; }
         ];
-        src = lib.cleanSourceWith { filter = sourceFilter;  src = ./.; };
+        # We can't filter paths with references in Nix 2.4
+        # See https://github.com/NixOS/nix/issues/5410
+        src = if (lib.versionOlder builtins.nixVersion "2.4")
+          then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
+          else ./.;
         authors = [
           "Peter Kolloch <info@eigenvalue.net>"
         ];

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -216,7 +216,7 @@ rec {
         ];
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder builtins.nixVersion "2.4")
+        src = if (lib.versionOlder builtins.nixVersion "2.4pre20211007")
           then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
           else ./.;
         authors = [

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -126,7 +126,7 @@ rec {
         ];
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder "2.4" builtins.nixVersion)
+        src = if (lib.versionOlder "2.4pre20211007" builtins.nixVersion)
           then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
           else ./.;
         authors = [

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -126,7 +126,7 @@ rec {
         ];
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder "2.4pre20211007" builtins.nixVersion)
+        src = if (lib.versionOlder builtins.nixVersion "2.4pre20211007")
           then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
           else ./.;
         authors = [

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -126,7 +126,7 @@ rec {
         ];
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
-        src = if (lib.versionOlder builtins.nixVersion "2.4")
+        src = if (lib.versionOlder "2.4" builtins.nixVersion)
           then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
           else ./.;
         authors = [

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -124,7 +124,11 @@ rec {
         crateBin = [
           { name = "sub_dir_crates"; path = "src/main.rs"; }
         ];
-        src = lib.cleanSourceWith { filter = sourceFilter;  src = ./.; };
+        # We can't filter paths with references in Nix 2.4
+        # See https://github.com/NixOS/nix/issues/5410
+        src = if (lib.versionOlder builtins.nixVersion "2.4")
+          then lib.cleanSourceWith { filter = sourceFilter;  src = ./.; }
+          else ./.;
         authors = [
           "Peter Kolloch <info@eigenvalue.net>"
         ];


### PR DESCRIPTION
Because of https://github.com/NixOS/nix/issues/5410, it's not possible
to filter paths with references anymore. This prevented any IFD-based
crate2nix usage. Fix this by not filtering the source when the Nix
version used includes the breaking commit.

Works around #213 