### PR TITLE
Fix logic for enabling features based on renamed dependencies

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -2818,15 +2818,14 @@ rec {
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = { name, rename ? null, ... }: feature:
+  doesFeatureEnableDependency = dependency: feature:
     let
+      name = dependency.rename or dependency.name;
       prefix = "${name}/";
       len = builtins.stringLength prefix;
       startsWithPrefix = builtins.substring 0 len feature == prefix;
     in
-    (rename == null && feature == name)
-    || (rename != null && rename == feature)
-    || startsWithPrefix;
+    feature == name || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the
     rules in featureMap.
@@ -2861,7 +2860,9 @@ rec {
             let
               enabled = builtins.any (doesFeatureEnableDependency dependency) features;
             in
-            if (dependency.optional or false) && enabled then [ dependency.name ] else [ ]
+            if (dependency.optional or false) && enabled
+            then [ (dependency.rename or dependency.name) ]
+            else [ ]
         )
         dependencies;
     in

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -561,15 +561,14 @@ rec {
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = { name, rename ? null, ... }: feature:
+  doesFeatureEnableDependency = dependency: feature:
     let
+      name = dependency.rename or dependency.name;
       prefix = "${name}/";
       len = builtins.stringLength prefix;
       startsWithPrefix = builtins.substring 0 len feature == prefix;
     in
-    (rename == null && feature == name)
-    || (rename != null && rename == feature)
-    || startsWithPrefix;
+    feature == name || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the
     rules in featureMap.
@@ -604,7 +603,9 @@ rec {
             let
               enabled = builtins.any (doesFeatureEnableDependency dependency) features;
             in
-            if (dependency.optional or false) && enabled then [ dependency.name ] else [ ]
+            if (dependency.optional or false) && enabled
+            then [ (dependency.rename or dependency.name) ]
+            else [ ]
         )
         dependencies;
     in

--- a/crate2nix/templates/nix/crate2nix/tests/default.nix
+++ b/crate2nix/templates/nix/crate2nix/tests/default.nix
@@ -2,7 +2,13 @@ let
   pkgs = import ../../../../../nix/nixpkgs.nix { };
   lib = pkgs.lib;
   crate2nix = pkgs.callPackage ../default.nix { };
-  testFiles = [ "dependencyDerivations" "dependencyFeatures" "expandFeatures" "packageFeatures" ];
+  testFiles = [
+    "dependencyDerivations"
+    "dependencyFeatures"
+    "enableFeatures"
+    "expandFeatures"
+    "packageFeatures"
+  ];
   testsInFile = f:
     let
       tests = (pkgs.callPackage (./. + "/${f}.nix")) { inherit crate2nix; };

--- a/crate2nix/templates/nix/crate2nix/tests/enableFeatures.nix
+++ b/crate2nix/templates/nix/crate2nix/tests/enableFeatures.nix
@@ -1,0 +1,64 @@
+{ lib, crate2nix }:
+let
+  exampleDependency = {
+    name = "dep";
+    packageId = "pkgid_dep";
+    optional = true;
+  };
+  renamedDependency = {
+    name = "dep";
+    rename = "dep2";
+    packageId = "pkgid_dep2";
+    optional = true;
+  };
+in
+{
+  testWithNoEnabledDependencies = {
+    expr = crate2nix.enableFeatures
+      [ exampleDependency ]
+      [ "default" ];
+    expected = [ "default" ];
+  };
+
+  testWithDirectlyEnabledDependency = {
+    expr = crate2nix.enableFeatures
+      [ exampleDependency ]
+      [ "default" "dep" ];
+    expected = [ "default" "dep" ];
+  };
+
+  testWithDirectlyEnabledRenamedDependency = {
+    expr = crate2nix.enableFeatures
+      [ renamedDependency ]
+      [ "default" "dep2" ];
+    expected = [ "default" "dep2" ];
+  };
+
+  testWithIndirectlyEnabledDependency = {
+    expr = crate2nix.enableFeatures
+      [ exampleDependency ]
+      [ "default" "dep/feat" ];
+    expected = [ "default" "dep" "dep/feat" ];
+  };
+
+  testWithIndirectlyEnabledRenamedDependency = {
+    expr = crate2nix.enableFeatures
+      [ renamedDependency ]
+      [ "default" "dep2/feat" ];
+    expected = [ "default" "dep2" "dep2/feat" ];
+  };
+
+  testWithDuplicateDependencies = {
+    expr = crate2nix.enableFeatures
+      [ exampleDependency renamedDependency ]
+      [ "default" "dep/feat" "dep2/feat" ];
+    expected = [ "default" "dep" "dep/feat" "dep2" "dep2/feat" ];
+  };
+
+  testWithDisabledRenamedDependency = {
+    expr = crate2nix.enableFeatures
+      [ renamedDependency ]
+      [ "default" "dep/feat" ];
+    expected = [ "default" "dep/feat" ];
+  };
+}

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -670,15 +670,14 @@ rec {
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = { name, rename ? null, ... }: feature:
+  doesFeatureEnableDependency = dependency: feature:
     let
+      name = dependency.rename or dependency.name;
       prefix = "${name}/";
       len = builtins.stringLength prefix;
       startsWithPrefix = builtins.substring 0 len feature == prefix;
     in
-    (rename == null && feature == name)
-    || (rename != null && rename == feature)
-    || startsWithPrefix;
+    feature == name || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the
     rules in featureMap.
@@ -713,7 +712,9 @@ rec {
             let
               enabled = builtins.any (doesFeatureEnableDependency dependency) features;
             in
-            if (dependency.optional or false) && enabled then [ dependency.name ] else [ ]
+            if (dependency.optional or false) && enabled
+            then [ (dependency.rename or dependency.name) ]
+            else [ ]
         )
         dependencies;
     in

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1843,15 +1843,14 @@ rec {
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = { name, rename ? null, ... }: feature:
+  doesFeatureEnableDependency = dependency: feature:
     let
+      name = dependency.rename or dependency.name;
       prefix = "${name}/";
       len = builtins.stringLength prefix;
       startsWithPrefix = builtins.substring 0 len feature == prefix;
     in
-    (rename == null && feature == name)
-    || (rename != null && rename == feature)
-    || startsWithPrefix;
+    feature == name || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the
     rules in featureMap.
@@ -1886,7 +1885,9 @@ rec {
             let
               enabled = builtins.any (doesFeatureEnableDependency dependency) features;
             in
-            if (dependency.optional or false) && enabled then [ dependency.name ] else [ ]
+            if (dependency.optional or false) && enabled
+            then [ (dependency.rename or dependency.name) ]
+            else [ ]
         )
         dependencies;
     in

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -1022,15 +1022,14 @@ rec {
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = { name, rename ? null, ... }: feature:
+  doesFeatureEnableDependency = dependency: feature:
     let
+      name = dependency.rename or dependency.name;
       prefix = "${name}/";
       len = builtins.stringLength prefix;
       startsWithPrefix = builtins.substring 0 len feature == prefix;
     in
-    (rename == null && feature == name)
-    || (rename != null && rename == feature)
-    || startsWithPrefix;
+    feature == name || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the
     rules in featureMap.
@@ -1065,7 +1064,9 @@ rec {
             let
               enabled = builtins.any (doesFeatureEnableDependency dependency) features;
             in
-            if (dependency.optional or false) && enabled then [ dependency.name ] else [ ]
+            if (dependency.optional or false) && enabled
+            then [ (dependency.rename or dependency.name) ]
+            else [ ]
         )
         dependencies;
     in

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -689,15 +689,14 @@ rec {
       dependencies;
 
   /* Returns whether the given feature should enable the given dependency. */
-  doesFeatureEnableDependency = { name, rename ? null, ... }: feature:
+  doesFeatureEnableDependency = dependency: feature:
     let
+      name = dependency.rename or dependency.name;
       prefix = "${name}/";
       len = builtins.stringLength prefix;
       startsWithPrefix = builtins.substring 0 len feature == prefix;
     in
-    (rename == null && feature == name)
-    || (rename != null && rename == feature)
-    || startsWithPrefix;
+    feature == name || startsWithPrefix;
 
   /* Returns the expanded features for the given inputFeatures by applying the
     rules in featureMap.
@@ -732,7 +731,9 @@ rec {
             let
               enabled = builtins.any (doesFeatureEnableDependency dependency) features;
             in
-            if (dependency.optional or false) && enabled then [ dependency.name ] else [ ]
+            if (dependency.optional or false) && enabled
+            then [ (dependency.rename or dependency.name) ]
+            else [ ]
         )
         dependencies;
     in


### PR DESCRIPTION
When `enableFeatures` inspects optional dependencies to enable additional features in accordance with https://doc.rust-lang.org/nightly/cargo/reference/features.html#dependency-features , it can incorrectly enable features for the original names of renamed dependencies, and fail to enable features for the new names. For example, diesel has a feature `"uuid"` which adds `uuid < 0.7.0` as a dependency, and a separate feature `"uuidv07"` which adds `uuid >= 0.7.0` renamed as `uuidv07`. When the `"uuidv07"` feature is enabled, `enableFeatures` sees that one of the features enables the dependency `uuid`, so it also enables the `"uuid"` feature. However, the relevant dependency was renamed, and the non-renamed `uuid < 0.7.0` required by the `"uuid"` feature isn't present among the dependencies, so the build breaks.  This patch fixes `enableFeatures` and `doesFeatureEnableDependency` to correctly handle renamed dependencies.