### PR TITLE
update README for upstream mozilla-overlay issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ in import sources.nixpkgs {
         # NOTE: "rust" instead of "rustc" is not a typo: It will include more than needed
         # but also the much needed "rust-std".
         rustc = super.latest.rustChannels.stable.rust;
-        inherit (super.latest.rustChannels.stable) cargo rust rust-fmt rust-std clippy;
+        inherit (super.latest.rustChannels.stable);
       })
     ];
   }


### PR DESCRIPTION
Hello all,

I recently followed the README to use a specific rust version with nixpkgs-mozilla overlay, and ran into an upstream error (`toRustTarget` missing) noted in the upstream issue https://github.com/mozilla/nixpkgs-mozilla/issues/232.

Reading this comment https://github.com/mozilla/nixpkgs-mozilla/issues/232#issuecomment-707883876  it seems the solution is to inherit all packages from the chosen rustChannel, to avoid mixing overlay and non-overlay packages.

I'm a newbie when it comes to github contributions, so any advice is greatly appreciated.

Thanks :smiley: 