### PR TITLE
Sort crateBin by name

### DIFF
--- a/crate2nix/templates/Cargo.nix.tera
+++ b/crate2nix/templates/Cargo.nix.tera
@@ -105,7 +105,8 @@ rec {
         crateBin = [];
         {%- elif crate.binaries|length > 0 and crate.is_root_or_workspace_member %}
         crateBin = [
-        {%- for bin in crate.binaries %}
+        {%- set bins_sorted = crate.binaries|sort(attribute="name") -%}
+        {%- for bin in bins_sorted %}
           { name = {{ bin.name }}; path = {{ bin.src_path }}; }
         {%- endfor %}
         ];


### PR DESCRIPTION
Sometimes `crate2nix generate` differently orders crateBin list and this confuses our CI which expects deterministic output. Unfortunately I cannot reproduce it anymore, but it happened on our big cargo workspace few times.