### PR TITLE
Fix applying overrides to defaultCrateOverrides when cross-compiling

### DIFF
--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -174,7 +174,7 @@ rec {
   buildRustCrateWithFeatures =
     { packageId
     , features ? rootFeatures
-    , crateOverrides ? defaultCrateOverrides
+    , crateOverrides ? null
     , buildRustCrateForPkgsFunc ? null
     , runTests ? false
     , testCrateFlags ? [ ]
@@ -200,7 +200,7 @@ rec {
             then buildRustCrateForPkgsFunc
             else
               (
-                if crateOverrides == pkgs.defaultCrateOverrides
+                if crateOverrides == null
                 then buildRustCrateForPkgs
                 else
                   pkgs: (buildRustCrateForPkgs pkgs).override {


### PR DESCRIPTION
When cross-compiling, there are different versions of `defaultCrateOverrides` for each platform. This causes `buildRustCrateWithFeatures` to think the user has passed a custom value of `crateOverrides`, which prevents the normal `defaultCrateOverrides` from being applied. To fix this, use a null default for `crateOverrides` to detect whether the user has actually specified a value.

This issue can be reproduced by applying a crate override as described here: https://github.com/kolloch/crate2nix#patching-crate-derivations-with-crateoverrides, and then attempting to cross-compile the package. The overrides will not be applied.