### PR TITLE
Cross compilation improvements

### DIFF
--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -179,6 +179,8 @@ rec {
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
+    # A function that takes in whether the crate is a build dependency, and what dependencies to add
+    , extraDepsIsBuild ? _: [ ]
       # Any command to run immediatelly before a test is executed.
     , testPreRun ? ""
       # Any command run immediatelly after a test is executed.
@@ -190,6 +192,7 @@ rec {
         , crateOverrides
         , runTests
         , testCrateFlags
+        , extraDepsIsBuild
         , testInputs
         , testPreRun
         , testPostRun
@@ -208,12 +211,12 @@ rec {
                   }
               );
           builtRustCrates = builtRustCratesWithFeatures {
-            inherit packageId features;
+            inherit packageId features extraDepsIsBuild;
             buildRustCrateForPkgsFunc = buildRustCrateForPkgsFuncOverriden;
             runTests = false;
           };
           builtTestRustCrates = builtRustCratesWithFeatures {
-            inherit packageId features;
+            inherit packageId features extraDepsIsBuild;
             buildRustCrateForPkgsFunc = buildRustCrateForPkgsFuncOverriden;
             runTests = true;
           };
@@ -231,7 +234,7 @@ rec {
         in
         derivation
       )
-      { inherit features crateOverrides runTests testCrateFlags testInputs testPreRun testPostRun; };
+      { inherit features crateOverrides runTests testCrateFlags testInputs testPreRun testPostRun extraDepsIsBuild; };
 
   /* Returns an attr set with packageId mapped to the result of buildRustCrateForPkgsFunc
     for the corresponding crate.
@@ -242,6 +245,7 @@ rec {
     , crateConfigs ? crates
     , buildRustCrateForPkgsFunc
     , runTests
+    , extraDepsIsBuild
     , makeTarget ? makeDefaultTarget
     } @ args:
       assert (builtins.isAttrs crateConfigs);
@@ -259,17 +263,17 @@ rec {
             }
           );
         # Memoize built packages so that reappearing packages are only built once.
-        builtByPackageIdByPkgs = mkBuiltByPackageIdByPkgs pkgs;
-        mkBuiltByPackageIdByPkgs = pkgs:
+        builtByPackageIdByPkgs = mkBuiltByPackageIdByPkgs false pkgs;
+        mkBuiltByPackageIdByPkgs = isBuildDep: pkgs:
           let
             self = {
-              crates = lib.mapAttrs (packageId: value: buildByPackageIdForPkgsImpl self pkgs packageId) crateConfigs;
-              target = makeTarget pkgs.stdenv.hostPlatform;
-              build = mkBuiltByPackageIdByPkgs pkgs.buildPackages;
+              crates = lib.mapAttrs (packageId: value: buildByPackageIdForPkgsImpl self pkgs packageId isBuildDep) crateConfigs;
+              target = makeTarget (if isBuildDep then stdenv.buildPlatform else stdenv.hostPlatform);
+              build = mkBuiltByPackageIdByPkgs true pkgs.buildPackages;
             };
           in
           self;
-        buildByPackageIdForPkgsImpl = self: pkgs: packageId:
+        buildByPackageIdForPkgsImpl = self: pkgs: packageId: isBuildDep:
           let
             features = mergedFeatures."${packageId}" or [ ];
             crateConfig' = crateConfigs."${packageId}";
@@ -280,7 +284,7 @@ rec {
                 (runTests && packageId == rootPackageId)
                 (crateConfig'.devDependencies or [ ]);
             dependencies =
-              dependencyDerivations {
+              (dependencyDerivations {
                 inherit features;
                 inherit (self) target;
                 buildByPackageId = depPackageId:
@@ -291,7 +295,7 @@ rec {
                 dependencies =
                   (crateConfig.dependencies or [ ])
                   ++ devDependencies;
-              };
+              }) ++ (extraDepsIsBuild isBuildDep);
             buildDependencies =
               dependencyDerivations {
                 inherit features;
@@ -351,6 +355,7 @@ rec {
                   }
                 );
                 extraRustcOpts = lib.lists.optional (targetFeatures != [ ]) "-C target-feature=${lib.concatMapStringsSep "," (x: "+${x}") targetFeatures}";
+                crossCompile = !isBuildDep;
                 inherit features dependencies buildDependencies crateRenames release;
               }
             );

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -39,7 +39,7 @@ rec {
       if platform.parsed.cpu.significantByte.name == "littleEndian"
       then "little" else "big";
     pointer_width = toString platform.parsed.cpu.bits;
-    vendor = platform.parsed.vendor.name;
+    vendor = platform.rustc.platform.vendor or platform.parsed.vendor.name;
     debug_assertions = false;
   };
 


### PR DESCRIPTION
My goal for cross compilation was to get [mustang](https://github.com/sunfishcode/mustang) targets working (which is successful with this patch). This differs a bit from standard nixpkgs cross compilation as it only needs to pass [--target](https://github.com/NixOS/nixpkgs/blob/refs%2Fheads%2Fnixpkgs-unstable/pkgs/build-support/rust/build-rust-crate/build-crate.nix#L23) to rustc (non rust targets do not need to be cross compiled). Thus, the goal of these changes is to make cross compilation less reliant on the inner workings of nixpkgs build stages.

1. The platform target now wholly relies on the `stdenv` passed in through calling `Cargo.nix` and acts similarily to `buildRustCrate`.
2. `mkBuiltByPackageIdByPkgs` is now aware if it is a build dependency (or proc-macro) and can act accordingly.
    a. It uses a tiny patch to [build-rust-crate](https://github.com/NixOS/nixpkgs/compare/master...jordanisaacs:nixpkgs:build-rust-cc) for an argument to disable cross compilation. Cross compilation gets disabled for build dependencies
    b. A new argument, `extraDepsIsBuild` is provided as an override to `.build`. This lets you add the sysroot crates *only* to non build dependencies.

While it works for my use case not sure if it breaks other uses or if there is a better way to achieve this.

An example (albeit a bit messy) is seen [here](https://github.com/jordanisaacs/snowfalldb/blob/fe896258f62bc57564537de700c43808e935b2d1/flake.nix#L72) and the sysroot is [here](https://github.com/jordanisaacs/snowfalldb/tree/main/nix). Special thanks to [alamgu](https://github.com/alamgu/alamgu) for providing some guidance.