### PR TITLE
Specify name in cleanSourceWith

### DIFF
--- a/crate2nix/templates/Cargo.nix.tera
+++ b/crate2nix/templates/Cargo.nix.tera
@@ -126,7 +126,7 @@ rec {
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
         src = if ((lib.versionOlder builtins.nixVersion "2.4pre20211007") || (lib.versionOlder "2.5" builtins.nixVersion ))
-          then lib.cleanSourceWith { filter = sourceFilter;  src = {{crate.source.LocalDirectory.path | safe}}; }
+          then lib.cleanSourceWith { name = crateName; filter = sourceFilter;  src = {{crate.source.LocalDirectory.path | safe}}; }
           else {{crate.source.LocalDirectory.path | safe}};
         {%- elif crate.source.Git %}
         workspace_member = null;


### PR DESCRIPTION
If you don't specify the name then the src name is used, which will be based on the _unfiltered_ source tree. This means that the output still depends on the input files that are filtered out, and extra builds are done that aren't needed.

I figured this out by debugging why changing any file in my git repo flake caused everything to be rebuilt again, which happens because the src name changes every time _anything_ is changed at all.

Ref: https://nixos.org/manual/nix/stable/language/builtins.html#builtins-filterSource