### PR TITLE
Add `additionalCrateHashes` to `generatedCargoNix`

### DIFF
--- a/tools.nix
+++ b/tools.nix
@@ -285,9 +285,10 @@ rec {
           };
 
         # Fetching git submodules with builtins.fetchGit is only supported in nix > 2.3
-        extraHashes = lib.optionalAttrs
-          (builtins.compareVersions builtins.nixVersion "2.3" == 1)
-          (builtins.listToAttrs (map mkGitHash unhashedGitDeps));
+        extraHashes = additionalCrateHashes //
+          lib.optionalAttrs
+            (builtins.compareVersions builtins.nixVersion "2.3" == 1)
+            (builtins.listToAttrs (map mkGitHash unhashedGitDeps));
 
         packages =
           let

--- a/tools.nix
+++ b/tools.nix
@@ -30,7 +30,7 @@ rec {
     , src
     , cargoToml ? "Cargo.toml"
     , additionalCargoNixArgs ? [ ]
-    , additionalCrateHashes ? {}
+    , additionalCrateHashes ? { }
     }:
     let
       crateDir = dirOf (src + "/${cargoToml}");
@@ -205,7 +205,7 @@ rec {
 
     vendorSupport =
       { crateDir ? ./.
-      , additionalCrateHashes ? {}
+      , additionalCrateHashes ? { }
       , ...
       }:
       rec {
@@ -256,8 +256,8 @@ rec {
               else { };
             parsedFiles = builtins.map parseFile hashesFiles;
           in
-            additionalCrateHashes //
-            lib.foldl (a: b: a // b) { } parsedFiles;
+          additionalCrateHashes //
+          lib.foldl (a: b: a // b) { } parsedFiles;
 
         unhashedGitDeps = builtins.filter (p: ! hashes ? ${toPackageId p}) packagesByType.git or [ ];
 

--- a/tools.nix
+++ b/tools.nix
@@ -287,7 +287,8 @@ rec {
               else builtins.throw "Checksum for ${name} not found in `hashes`");
           };
 
-        extendedHashes = hashes // (builtins.listToAttrs (map mkGitHash (packagesByType.git or [ ])));
+        extendedHashes = hashes
+          // builtins.listToAttrs (map mkGitHash (packagesByType.git or [ ]));
 
         packages =
           let


### PR DESCRIPTION
This makes it easy to use a `crate-hashes.json` that is outside any source tree. By default it is the `crate-hashes.json` at the root of the source tree. Additional such files next to any `Cargo.lock` will also be used unconditionally.

Behind the scenes, the vendor support was already reworked to separate more opinionated gathering lockfiles and `crate-hashes.json` from the basic `crate2nix`-agnostic work of creating the vendor dir. This cleans up the code, and makes supporting the new feature easier too.

Finally, let me note one thing as future work. In https://github.com/NixOS/nixpkgs/pull/217084 I learned from @winterqt that Nixpkgs now has a `importCargoLock`. It would be very nice to drop the vendoring logic from `tools.nix` and use that instead, now that the `crate2nix`-specific bits have been pulled out as described above.