### PR TITLE
src/render.rs: handle CfgExpr::Any(vec![])

### DIFF
--- a/crate2nix/src/render.rs
+++ b/crate2nix/src/render.rs
@@ -241,6 +241,8 @@ fn cfg_to_nix_expr(cfg: &CfgExpr) -> String {
                 }
                 result.push(')');
             }
+            CfgExpr::Any(expressions) if expressions.len() == 0 =>
+                result.push_str("false"),
             CfgExpr::Any(expressions) => {
                 result.push('(');
                 render(result, &expressions[0]);


### PR DESCRIPTION
Apparently `CfgExpr::Any(vec![])` occurs in the wild.  Encountered while crate2nixifying `cosmic-comp`.