### PR TITLE
Allow customizing sourceFilter to build file

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -26,6 +26,8 @@
   ? if builtins.pathExists ./crate-config.nix
     then pkgs.callPackage ./crate-config.nix {}
     else {}
+  # Custom source filter function
+, sourceFilter ? null
 }:
 
 rec {
@@ -480,7 +482,7 @@ rec {
             requiredFeatures = [ ];
           }
         ];
-        src = lib.cleanSourceWith { filter = sourceFilter;  src = ./.; };
+        src = lib.cleanSourceWith { filter = (if sourceFilter == null then defaultSourceFilter else sourceFilter); src = ./.; };
         authors = [
           "Peter Kolloch <info@eigenvalue.net>"
         ];
@@ -3214,7 +3216,7 @@ rec {
 
   # Filters common temp files and build files.
   # TODO(pkolloch): Substitute with gitignore filter
-  sourceFilter =
+  defaultSourceFilter =
     name: type:
     let
       baseName = builtins.baseNameOf (builtins.toString name);

--- a/crate2nix/templates/Cargo.nix.tera
+++ b/crate2nix/templates/Cargo.nix.tera
@@ -28,6 +28,8 @@
   ? if builtins.pathExists ./crate-config.nix
     then pkgs.callPackage ./crate-config.nix {}
     else {}
+  # Custom source filter function
+, sourceFilter ? null
 }:
 
 rec {
@@ -153,7 +155,7 @@ rec {
         {%- elif crate.source.Nix.file.package %}
         src = pkgs.callPackage {{crate.source.Nix.file.package | safe}} {};
         {%- elif crate.source.LocalDirectory.path %}
-        src = lib.cleanSourceWith { filter = sourceFilter;  src = {{crate.source.LocalDirectory.path | safe}}; };
+        src = lib.cleanSourceWith { filter = (if sourceFilter == null then defaultSourceFilter else sourceFilter); src = {{crate.source.LocalDirectory.path | safe}}; };
         {%- elif crate.source.Git %}
         workspace_member = null;
         src = pkgs.fetchgit {

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -15,6 +15,7 @@
 , rootFeatures ? [ ]
 , targetFeatures ? [ ]
 , release ? true
+, sourceFilter ? null
 ,
 }:
 rec {
@@ -85,7 +86,7 @@ rec {
 
   # Filters common temp files and build files.
   # TODO(pkolloch): Substitute with gitignore filter
-  sourceFilter =
+  defaultSourceFilter =
     name: type:
     let
       baseName = builtins.baseNameOf (builtins.toString name);

--- a/docs/src/content/docs/00_guides/90_overriding_source_filter.mdx
+++ b/docs/src/content/docs/00_guides/90_overriding_source_filter.mdx
@@ -1,0 +1,24 @@
+---
+title: Overriding Source Filter
+---
+
+There is a defaultSourceFilter function that is built in to crate2nix, which is used to pass a clean source tree to the derivation. It has sane defaults but it can be helpful to be able override it on a project specific basis.
+
+When importing the build file pass in a `sourceFilter`. `sourceFilter` is a `(path -> type -> bool)` filter function that will be passed into [`lib.cleanSourceWith`](https://nixos.org/manual/nixpkgs/stable/#function-library-lib.sources.cleanSourceWith).
+
+This would allow all files through:
+
+```nix
+let cargo_nix = callPackage ./Cargo.nix { sourceFilter = _: _: true };
+  crate2nix = cargo_nix.rootCrate.build;
+in ...
+```
+
+You could also use something like [gitignore.nix](https://github.com/hercules-ci/gitignore.nix) to filter out files included in your `.gitignore`:
+
+```nix
+let gitignoreFilter = gitignore.lib.gitignoreFilter ./.;
+  cargo_nix = callPackage ./Cargo.nix { sourceFilter = gitignoreFilter; };
+  crate2nix = cargo_nix.rootCrate.build;
+in ...
+```

--- a/docs/src/content/docs/90_reference/90_CHANGELOG.md
+++ b/docs/src/content/docs/90_reference/90_CHANGELOG.md
@@ -6,6 +6,7 @@ description: A list of all major changes per version.
 ## 0.14.x - 0.15.0 (unreleased)
 
 * [#359](https://github.com/nix-community/crate2nix/issues/359): Document using `rust-overlay`.
+* [#405](https://github.com/nix-community/crate2nix/pull/405): Allow settting a custom sourceFilter when calling build file.
 
 ## 0.14.x - 0.14.1 (2024-06-30)
 

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -26,6 +26,8 @@
   ? if builtins.pathExists ./crate-config.nix
     then pkgs.callPackage ./crate-config.nix {}
     else {}
+  # Custom source filter function
+, sourceFilter ? null
 }:
 
 rec {
@@ -124,7 +126,7 @@ rec {
             requiredFeatures = [ ];
           }
         ];
-        src = lib.cleanSourceWith { filter = sourceFilter;  src = ./.; };
+        src = lib.cleanSourceWith { filter = (if sourceFilter == null then defaultSourceFilter else sourceFilter); src = ./.; };
         authors = [
           "Phillip Cloud <cloud@standard.ai>"
         ];
@@ -1432,7 +1434,7 @@ rec {
 
   # Filters common temp files and build files.
   # TODO(pkolloch): Substitute with gitignore filter
-  sourceFilter =
+  defaultSourceFilter =
     name: type:
     let
       baseName = builtins.baseNameOf (builtins.toString name);

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -26,6 +26,8 @@
   ? if builtins.pathExists ./crate-config.nix
     then pkgs.callPackage ./crate-config.nix {}
     else {}
+  # Custom source filter function
+, sourceFilter ? null
 }:
 
 rec {
@@ -226,7 +228,7 @@ rec {
             requiredFeatures = [ ];
           }
         ];
-        src = lib.cleanSourceWith { filter = sourceFilter;  src = ./.; };
+        src = lib.cleanSourceWith { filter = (if sourceFilter == null then defaultSourceFilter else sourceFilter); src = ./.; };
         authors = [
           "Peter Kolloch <info@eigenvalue.net>"
         ];
@@ -607,7 +609,7 @@ rec {
 
   # Filters common temp files and build files.
   # TODO(pkolloch): Substitute with gitignore filter
-  sourceFilter =
+  defaultSourceFilter =
     name: type:
     let
       baseName = builtins.baseNameOf (builtins.toString name);

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -26,6 +26,8 @@
   ? if builtins.pathExists ./crate-config.nix
     then pkgs.callPackage ./crate-config.nix {}
     else {}
+  # Custom source filter function
+, sourceFilter ? null
 }:
 
 rec {
@@ -129,7 +131,7 @@ rec {
             requiredFeatures = [ ];
           }
         ];
-        src = lib.cleanSourceWith { filter = sourceFilter;  src = ./.; };
+        src = lib.cleanSourceWith { filter = (if sourceFilter == null then defaultSourceFilter else sourceFilter); src = ./.; };
         authors = [
           "Peter Kolloch <info@eigenvalue.net>"
         ];
@@ -216,7 +218,7 @@ rec {
 
   # Filters common temp files and build files.
   # TODO(pkolloch): Substitute with gitignore filter
-  sourceFilter =
+  defaultSourceFilter =
     name: type:
     let
       baseName = builtins.baseNameOf (builtins.toString name);


### PR DESCRIPTION
Allow passing in a `sourceFilter` argument into the `Cargo.nix`.

See #287 

cc @flokli 