### PR TITLE
fix: typo immediatelly -> immediately

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -3394,9 +3394,9 @@ rec {
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
-    , # Any command to run immediatelly before a test is executed.
+    , # Any command to run immediately before a test is executed.
       testPreRun ? ""
-    , # Any command run immediatelly after a test is executed.
+    , # Any command run immediately after a test is executed.
       testPostRun ? ""
     ,
     }:

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -230,9 +230,9 @@ rec {
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
-    , # Any command to run immediatelly before a test is executed.
+    , # Any command to run immediately before a test is executed.
       testPreRun ? ""
-    , # Any command run immediatelly after a test is executed.
+    , # Any command run immediately after a test is executed.
       testPostRun ? ""
     ,
     }:

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1593,9 +1593,9 @@ rec {
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
-    , # Any command to run immediatelly before a test is executed.
+    , # Any command to run immediately before a test is executed.
       testPreRun ? ""
-    , # Any command run immediatelly after a test is executed.
+    , # Any command run immediately after a test is executed.
       testPostRun ? ""
     ,
     }:

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -762,9 +762,9 @@ rec {
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
-    , # Any command to run immediatelly before a test is executed.
+    , # Any command to run immediately before a test is executed.
       testPreRun ? ""
-    , # Any command run immediatelly after a test is executed.
+    , # Any command run immediately after a test is executed.
       testPostRun ? ""
     ,
     }:

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -364,9 +364,9 @@ rec {
     , runTests ? false
     , testCrateFlags ? [ ]
     , testInputs ? [ ]
-    , # Any command to run immediatelly before a test is executed.
+    , # Any command to run immediately before a test is executed.
       testPreRun ? ""
-    , # Any command run immediatelly after a test is executed.
+    , # Any command run immediately after a test is executed.
       testPostRun ? ""
     ,
     }:


### PR DESCRIPTION
In my own project, using the autogenerated Cargo.nix, [`typos`](https://github.com/crate-ci/typos) was picking up on the typo in the auto-generated file.