### PR TITLE
Add useNextest option for running tests with cargo-nextest

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -3306,12 +3306,14 @@ rec {
     , testInputs
     , testPreRun
     , testPostRun
+    , useNextest ? false
     ,
     }:
       assert builtins.typeOf testCrateFlags == "list";
       assert builtins.typeOf testInputs == "list";
       assert builtins.typeOf testPreRun == "string";
       assert builtins.typeOf testPostRun == "string";
+      assert builtins.typeOf useNextest == "bool";
       let
         # override the `crate` so that it will build and execute tests instead of
         # building the actual lib and bin targets We just have to pass `--test`
@@ -3342,6 +3344,10 @@ rec {
 
             buildInputs = testInputs;
 
+            nativeBuildInputs = lib.optionals useNextest [
+              pkgs.cargo-nextest
+            ];
+
             buildPhase = ''
               set -e
               export RUST_BACKTRACE=1
@@ -3364,8 +3370,45 @@ rec {
               for file in ${drv}/tests/*; do
                 f=$testRoot/$(basename $file)-$hash
                 cp $file $f
-                ${testCommand}
+                ${if useNextest then "" else testCommand}
               done
+            '' + lib.optionalString useNextest ''
+
+              # Generate synthetic cargo and nextest metadata to run
+              # pre-built test binaries via cargo-nextest.
+              crateName="${testCrate.crateName or testCrate.name}"
+              pkgId="$crateName 0.0.0 (path+file://$(pwd))"
+
+              # Minimal cargo metadata
+              cat > cargo-metadata.json <<CARGO_META_EOF
+              {"packages":[{"name":"$crateName","version":"0.0.0","id":"$pkgId","manifest_path":"$(pwd)/Cargo.toml","targets":[],"features":{},"dependencies":[],"edition":"2021","source":null}],"workspace_members":["$pkgId"],"workspace_default_members":["$pkgId"],"resolve":null,"target_directory":"$(pwd)/target","version":1,"workspace_root":"$(pwd)"}
+              CARGO_META_EOF
+
+              # Nextest binaries metadata
+              printf '{"rust-build-meta":{"target-directory":"%s/target","base-output-directories":["debug"],"non-test-binaries":{},"linked-paths":[]},"rust-binaries":{' \
+                "$(pwd)" > binaries-metadata.json
+
+              first=true
+              for file in ${drv}/tests/*; do
+                name=$(basename "$file")
+                binPath=$(pwd)/$testRoot/$name-$hash
+                if [ "$first" = true ]; then
+                  first=false
+                else
+                  printf ',' >> binaries-metadata.json
+                fi
+                printf '"%s::test/%s":{"binary-id":"%s::test/%s","binary-name":"%s","package-id":"%s","kind":"test","binary-path":"%s","build-platform":"target"}' \
+                  "$crateName" "$name" "$crateName" "$name" "$name" "$pkgId" "$binPath" >> binaries-metadata.json
+              done
+              printf '}}' >> binaries-metadata.json
+
+              ${testPreRun}
+              cargo-nextest nextest run \
+                --binaries-metadata "$(pwd)/binaries-metadata.json" \
+                --cargo-metadata "$(pwd)/cargo-metadata.json" \
+                --workspace-remap "$(pwd)" \
+                $testCrateFlags 2>&1 | tee -a $out
+              ${testPostRun}
             '';
           };
       in
@@ -3398,6 +3441,8 @@ rec {
       testPreRun ? ""
     , # Any command run immediatelly after a test is executed.
       testPostRun ? ""
+    , # Use cargo-nextest to run tests instead of running test binaries directly.
+      useNextest ? false
     ,
     }:
     lib.makeOverridable
@@ -3409,6 +3454,7 @@ rec {
         , testInputs
         , testPreRun
         , testPostRun
+        , useNextest
         ,
         }:
         let
@@ -3448,6 +3494,7 @@ rec {
                     testInputs
                     testPreRun
                     testPostRun
+                    useNextest
                     ;
                 }
             else
@@ -3464,6 +3511,7 @@ rec {
           testInputs
           testPreRun
           testPostRun
+          useNextest
           ;
       };
 

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -142,12 +142,14 @@ rec {
     , testInputs
     , testPreRun
     , testPostRun
+    , useNextest ? false
     ,
     }:
       assert builtins.typeOf testCrateFlags == "list";
       assert builtins.typeOf testInputs == "list";
       assert builtins.typeOf testPreRun == "string";
       assert builtins.typeOf testPostRun == "string";
+      assert builtins.typeOf useNextest == "bool";
       let
         # override the `crate` so that it will build and execute tests instead of
         # building the actual lib and bin targets We just have to pass `--test`
@@ -178,6 +180,10 @@ rec {
 
             buildInputs = testInputs;
 
+            nativeBuildInputs = lib.optionals useNextest [
+              pkgs.cargo-nextest
+            ];
+
             buildPhase = ''
               set -e
               export RUST_BACKTRACE=1
@@ -200,8 +206,45 @@ rec {
               for file in ${drv}/tests/*; do
                 f=$testRoot/$(basename $file)-$hash
                 cp $file $f
-                ${testCommand}
+                ${if useNextest then "" else testCommand}
               done
+            '' + lib.optionalString useNextest ''
+
+              # Generate synthetic cargo and nextest metadata to run
+              # pre-built test binaries via cargo-nextest.
+              crateName="${testCrate.crateName or testCrate.name}"
+              pkgId="$crateName 0.0.0 (path+file://$(pwd))"
+
+              # Minimal cargo metadata
+              cat > cargo-metadata.json <<CARGO_META_EOF
+              {"packages":[{"name":"$crateName","version":"0.0.0","id":"$pkgId","manifest_path":"$(pwd)/Cargo.toml","targets":[],"features":{},"dependencies":[],"edition":"2021","source":null}],"workspace_members":["$pkgId"],"workspace_default_members":["$pkgId"],"resolve":null,"target_directory":"$(pwd)/target","version":1,"workspace_root":"$(pwd)"}
+              CARGO_META_EOF
+
+              # Nextest binaries metadata
+              printf '{"rust-build-meta":{"target-directory":"%s/target","base-output-directories":["debug"],"non-test-binaries":{},"linked-paths":[]},"rust-binaries":{' \
+                "$(pwd)" > binaries-metadata.json
+
+              first=true
+              for file in ${drv}/tests/*; do
+                name=$(basename "$file")
+                binPath=$(pwd)/$testRoot/$name-$hash
+                if [ "$first" = true ]; then
+                  first=false
+                else
+                  printf ',' >> binaries-metadata.json
+                fi
+                printf '"%s::test/%s":{"binary-id":"%s::test/%s","binary-name":"%s","package-id":"%s","kind":"test","binary-path":"%s","build-platform":"target"}' \
+                  "$crateName" "$name" "$crateName" "$name" "$name" "$pkgId" "$binPath" >> binaries-metadata.json
+              done
+              printf '}}' >> binaries-metadata.json
+
+              ${testPreRun}
+              cargo-nextest nextest run \
+                --binaries-metadata "$(pwd)/binaries-metadata.json" \
+                --cargo-metadata "$(pwd)/cargo-metadata.json" \
+                --workspace-remap "$(pwd)" \
+                $testCrateFlags 2>&1 | tee -a $out
+              ${testPostRun}
             '';
           };
       in
@@ -234,6 +277,8 @@ rec {
       testPreRun ? ""
     , # Any command run immediatelly after a test is executed.
       testPostRun ? ""
+    , # Use cargo-nextest to run tests instead of running test binaries directly.
+      useNextest ? false
     ,
     }:
     lib.makeOverridable
@@ -245,6 +290,7 @@ rec {
         , testInputs
         , testPreRun
         , testPostRun
+        , useNextest
         ,
         }:
         let
@@ -284,6 +330,7 @@ rec {
                     testInputs
                     testPreRun
                     testPostRun
+                    useNextest
                     ;
                 }
             else
@@ -300,6 +347,7 @@ rec {
           testInputs
           testPreRun
           testPostRun
+          useNextest
           ;
       };
 

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1505,12 +1505,14 @@ rec {
     , testInputs
     , testPreRun
     , testPostRun
+    , useNextest ? false
     ,
     }:
       assert builtins.typeOf testCrateFlags == "list";
       assert builtins.typeOf testInputs == "list";
       assert builtins.typeOf testPreRun == "string";
       assert builtins.typeOf testPostRun == "string";
+      assert builtins.typeOf useNextest == "bool";
       let
         # override the `crate` so that it will build and execute tests instead of
         # building the actual lib and bin targets We just have to pass `--test`
@@ -1541,6 +1543,10 @@ rec {
 
             buildInputs = testInputs;
 
+            nativeBuildInputs = lib.optionals useNextest [
+              pkgs.cargo-nextest
+            ];
+
             buildPhase = ''
               set -e
               export RUST_BACKTRACE=1
@@ -1563,8 +1569,45 @@ rec {
               for file in ${drv}/tests/*; do
                 f=$testRoot/$(basename $file)-$hash
                 cp $file $f
-                ${testCommand}
+                ${if useNextest then "" else testCommand}
               done
+            '' + lib.optionalString useNextest ''
+
+              # Generate synthetic cargo and nextest metadata to run
+              # pre-built test binaries via cargo-nextest.
+              crateName="${testCrate.crateName or testCrate.name}"
+              pkgId="$crateName 0.0.0 (path+file://$(pwd))"
+
+              # Minimal cargo metadata
+              cat > cargo-metadata.json <<CARGO_META_EOF
+              {"packages":[{"name":"$crateName","version":"0.0.0","id":"$pkgId","manifest_path":"$(pwd)/Cargo.toml","targets":[],"features":{},"dependencies":[],"edition":"2021","source":null}],"workspace_members":["$pkgId"],"workspace_default_members":["$pkgId"],"resolve":null,"target_directory":"$(pwd)/target","version":1,"workspace_root":"$(pwd)"}
+              CARGO_META_EOF
+
+              # Nextest binaries metadata
+              printf '{"rust-build-meta":{"target-directory":"%s/target","base-output-directories":["debug"],"non-test-binaries":{},"linked-paths":[]},"rust-binaries":{' \
+                "$(pwd)" > binaries-metadata.json
+
+              first=true
+              for file in ${drv}/tests/*; do
+                name=$(basename "$file")
+                binPath=$(pwd)/$testRoot/$name-$hash
+                if [ "$first" = true ]; then
+                  first=false
+                else
+                  printf ',' >> binaries-metadata.json
+                fi
+                printf '"%s::test/%s":{"binary-id":"%s::test/%s","binary-name":"%s","package-id":"%s","kind":"test","binary-path":"%s","build-platform":"target"}' \
+                  "$crateName" "$name" "$crateName" "$name" "$name" "$pkgId" "$binPath" >> binaries-metadata.json
+              done
+              printf '}}' >> binaries-metadata.json
+
+              ${testPreRun}
+              cargo-nextest nextest run \
+                --binaries-metadata "$(pwd)/binaries-metadata.json" \
+                --cargo-metadata "$(pwd)/cargo-metadata.json" \
+                --workspace-remap "$(pwd)" \
+                $testCrateFlags 2>&1 | tee -a $out
+              ${testPostRun}
             '';
           };
       in
@@ -1597,6 +1640,8 @@ rec {
       testPreRun ? ""
     , # Any command run immediatelly after a test is executed.
       testPostRun ? ""
+    , # Use cargo-nextest to run tests instead of running test binaries directly.
+      useNextest ? false
     ,
     }:
     lib.makeOverridable
@@ -1608,6 +1653,7 @@ rec {
         , testInputs
         , testPreRun
         , testPostRun
+        , useNextest
         ,
         }:
         let
@@ -1647,6 +1693,7 @@ rec {
                     testInputs
                     testPreRun
                     testPostRun
+                    useNextest
                     ;
                 }
             else
@@ -1663,6 +1710,7 @@ rec {
           testInputs
           testPreRun
           testPostRun
+          useNextest
           ;
       };
 

--- a/sample_projects/cfg-test/test-nextest.nix
+++ b/sample_projects/cfg-test/test-nextest.nix
@@ -1,5 +1,5 @@
 { pkgs ? import ../../nix/nixpkgs.nix { config = { }; }
-, generatedCargoNix ? ./Cargo.nix
+, generatedCargoNix ? ./Cargo.nix { }
 }:
 let
   instantiatedBuild = pkgs.callPackage generatedCargoNix { };
@@ -7,4 +7,5 @@ in
 instantiatedBuild.rootCrate.build.override {
   runTests = true;
   useNextest = true;
+  testInputs = [ pkgs.cowsay ];
 }

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -674,12 +674,14 @@ rec {
     , testInputs
     , testPreRun
     , testPostRun
+    , useNextest ? false
     ,
     }:
       assert builtins.typeOf testCrateFlags == "list";
       assert builtins.typeOf testInputs == "list";
       assert builtins.typeOf testPreRun == "string";
       assert builtins.typeOf testPostRun == "string";
+      assert builtins.typeOf useNextest == "bool";
       let
         # override the `crate` so that it will build and execute tests instead of
         # building the actual lib and bin targets We just have to pass `--test`
@@ -710,6 +712,10 @@ rec {
 
             buildInputs = testInputs;
 
+            nativeBuildInputs = lib.optionals useNextest [
+              pkgs.cargo-nextest
+            ];
+
             buildPhase = ''
               set -e
               export RUST_BACKTRACE=1
@@ -732,8 +738,45 @@ rec {
               for file in ${drv}/tests/*; do
                 f=$testRoot/$(basename $file)-$hash
                 cp $file $f
-                ${testCommand}
+                ${if useNextest then "" else testCommand}
               done
+            '' + lib.optionalString useNextest ''
+
+              # Generate synthetic cargo and nextest metadata to run
+              # pre-built test binaries via cargo-nextest.
+              crateName="${testCrate.crateName or testCrate.name}"
+              pkgId="$crateName 0.0.0 (path+file://$(pwd))"
+
+              # Minimal cargo metadata
+              cat > cargo-metadata.json <<CARGO_META_EOF
+              {"packages":[{"name":"$crateName","version":"0.0.0","id":"$pkgId","manifest_path":"$(pwd)/Cargo.toml","targets":[],"features":{},"dependencies":[],"edition":"2021","source":null}],"workspace_members":["$pkgId"],"workspace_default_members":["$pkgId"],"resolve":null,"target_directory":"$(pwd)/target","version":1,"workspace_root":"$(pwd)"}
+              CARGO_META_EOF
+
+              # Nextest binaries metadata
+              printf '{"rust-build-meta":{"target-directory":"%s/target","base-output-directories":["debug"],"non-test-binaries":{},"linked-paths":[]},"rust-binaries":{' \
+                "$(pwd)" > binaries-metadata.json
+
+              first=true
+              for file in ${drv}/tests/*; do
+                name=$(basename "$file")
+                binPath=$(pwd)/$testRoot/$name-$hash
+                if [ "$first" = true ]; then
+                  first=false
+                else
+                  printf ',' >> binaries-metadata.json
+                fi
+                printf '"%s::test/%s":{"binary-id":"%s::test/%s","binary-name":"%s","package-id":"%s","kind":"test","binary-path":"%s","build-platform":"target"}' \
+                  "$crateName" "$name" "$crateName" "$name" "$name" "$pkgId" "$binPath" >> binaries-metadata.json
+              done
+              printf '}}' >> binaries-metadata.json
+
+              ${testPreRun}
+              cargo-nextest nextest run \
+                --binaries-metadata "$(pwd)/binaries-metadata.json" \
+                --cargo-metadata "$(pwd)/cargo-metadata.json" \
+                --workspace-remap "$(pwd)" \
+                $testCrateFlags 2>&1 | tee -a $out
+              ${testPostRun}
             '';
           };
       in
@@ -766,6 +809,8 @@ rec {
       testPreRun ? ""
     , # Any command run immediatelly after a test is executed.
       testPostRun ? ""
+    , # Use cargo-nextest to run tests instead of running test binaries directly.
+      useNextest ? false
     ,
     }:
     lib.makeOverridable
@@ -777,6 +822,7 @@ rec {
         , testInputs
         , testPreRun
         , testPostRun
+        , useNextest
         ,
         }:
         let
@@ -816,6 +862,7 @@ rec {
                     testInputs
                     testPreRun
                     testPostRun
+                    useNextest
                     ;
                 }
             else
@@ -832,6 +879,7 @@ rec {
           testInputs
           testPreRun
           testPostRun
+          useNextest
           ;
       };
 

--- a/sample_projects/integration_test/test-nextest.nix
+++ b/sample_projects/integration_test/test-nextest.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import ../../nix/nixpkgs.nix { config = { }; }
+, generatedCargoNix ? ./Cargo.nix
+}:
+let
+  instantiatedBuild = pkgs.callPackage generatedCargoNix { };
+in
+instantiatedBuild.rootCrate.build.override {
+  runTests = true;
+  useNextest = true;
+}

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -276,12 +276,14 @@ rec {
     , testInputs
     , testPreRun
     , testPostRun
+    , useNextest ? false
     ,
     }:
       assert builtins.typeOf testCrateFlags == "list";
       assert builtins.typeOf testInputs == "list";
       assert builtins.typeOf testPreRun == "string";
       assert builtins.typeOf testPostRun == "string";
+      assert builtins.typeOf useNextest == "bool";
       let
         # override the `crate` so that it will build and execute tests instead of
         # building the actual lib and bin targets We just have to pass `--test`
@@ -312,6 +314,10 @@ rec {
 
             buildInputs = testInputs;
 
+            nativeBuildInputs = lib.optionals useNextest [
+              pkgs.cargo-nextest
+            ];
+
             buildPhase = ''
               set -e
               export RUST_BACKTRACE=1
@@ -334,8 +340,45 @@ rec {
               for file in ${drv}/tests/*; do
                 f=$testRoot/$(basename $file)-$hash
                 cp $file $f
-                ${testCommand}
+                ${if useNextest then "" else testCommand}
               done
+            '' + lib.optionalString useNextest ''
+
+              # Generate synthetic cargo and nextest metadata to run
+              # pre-built test binaries via cargo-nextest.
+              crateName="${testCrate.crateName or testCrate.name}"
+              pkgId="$crateName 0.0.0 (path+file://$(pwd))"
+
+              # Minimal cargo metadata
+              cat > cargo-metadata.json <<CARGO_META_EOF
+              {"packages":[{"name":"$crateName","version":"0.0.0","id":"$pkgId","manifest_path":"$(pwd)/Cargo.toml","targets":[],"features":{},"dependencies":[],"edition":"2021","source":null}],"workspace_members":["$pkgId"],"workspace_default_members":["$pkgId"],"resolve":null,"target_directory":"$(pwd)/target","version":1,"workspace_root":"$(pwd)"}
+              CARGO_META_EOF
+
+              # Nextest binaries metadata
+              printf '{"rust-build-meta":{"target-directory":"%s/target","base-output-directories":["debug"],"non-test-binaries":{},"linked-paths":[]},"rust-binaries":{' \
+                "$(pwd)" > binaries-metadata.json
+
+              first=true
+              for file in ${drv}/tests/*; do
+                name=$(basename "$file")
+                binPath=$(pwd)/$testRoot/$name-$hash
+                if [ "$first" = true ]; then
+                  first=false
+                else
+                  printf ',' >> binaries-metadata.json
+                fi
+                printf '"%s::test/%s":{"binary-id":"%s::test/%s","binary-name":"%s","package-id":"%s","kind":"test","binary-path":"%s","build-platform":"target"}' \
+                  "$crateName" "$name" "$crateName" "$name" "$name" "$pkgId" "$binPath" >> binaries-metadata.json
+              done
+              printf '}}' >> binaries-metadata.json
+
+              ${testPreRun}
+              cargo-nextest nextest run \
+                --binaries-metadata "$(pwd)/binaries-metadata.json" \
+                --cargo-metadata "$(pwd)/cargo-metadata.json" \
+                --workspace-remap "$(pwd)" \
+                $testCrateFlags 2>&1 | tee -a $out
+              ${testPostRun}
             '';
           };
       in
@@ -368,6 +411,8 @@ rec {
       testPreRun ? ""
     , # Any command run immediatelly after a test is executed.
       testPostRun ? ""
+    , # Use cargo-nextest to run tests instead of running test binaries directly.
+      useNextest ? false
     ,
     }:
     lib.makeOverridable
@@ -379,6 +424,7 @@ rec {
         , testInputs
         , testPreRun
         , testPostRun
+        , useNextest
         ,
         }:
         let
@@ -418,6 +464,7 @@ rec {
                     testInputs
                     testPreRun
                     testPostRun
+                    useNextest
                     ;
                 }
             else
@@ -434,6 +481,7 @@ rec {
           testInputs
           testPreRun
           testPostRun
+          useNextest
           ;
       };
 

--- a/tests.nix
+++ b/tests.nix
@@ -387,15 +387,17 @@ let
     }
 
     {
-      name = "integration_test_nextest";
-      src = ./sample_projects/integration_test;
+      name = "cfg_test-with-tests-nextest";
+      src = ./sample_projects/cfg-test;
       cargoToml = "Cargo.toml";
-      customBuild = "sample_projects/integration_test/test-nextest.nix";
-      expectedOutput = "expected one argument";
+      customBuild = "sample_projects/cfg-test/test-nextest.nix";
+      expectedOutput = "Hello, cfg-test!";
       expectedTestOutputs = [
-        "read_source_file"
-        "write_output_file"
-        "2 passed"
+        "echo_foo_test"
+        "lib_test"
+        "in_source_dir"
+        "exec_cowsay"
+        "4 passed"
       ];
     }
 

--- a/tests.nix
+++ b/tests.nix
@@ -387,6 +387,19 @@ let
     }
 
     {
+      name = "integration_test_nextest";
+      src = ./sample_projects/integration_test;
+      cargoToml = "Cargo.toml";
+      customBuild = "sample_projects/integration_test/test-nextest.nix";
+      expectedOutput = "expected one argument";
+      expectedTestOutputs = [
+        "read_source_file"
+        "write_output_file"
+        "2 passed"
+      ];
+    }
+
+    {
       name = "cross_compile_build_dependencies";
       src = ./sample_projects/cross_compile_build_dependencies;
       customBuild = "sample_projects/cross_compile_build_dependencies/default.nix";


### PR DESCRIPTION
## Summary
- Adds `useNextest` parameter to `buildRustCrateWithFeatures`; when true, pre-built test binaries are run via `cargo-nextest` for faster per-testcase parallel execution
- Generates synthetic `--cargo-metadata` and `--binaries-metadata` JSON so nextest can run binaries built by `buildRustCrate` (no cargo required in the test derivation)
- Adds `integration_test_nextest` sample + check that exercises the feature end-to-end

## Test plan
- [ ] `nix-build tests.nix -A checks.integration_test_nextest -L` passes
- [ ] `nix flake check -L` passes (existing tests unaffected when `useNextest` is not set)
- [ ] Existing `integration_test` still passes (default path unchanged)