### PR TITLE
fix: guard .override on buildRustCrateForPkgs result in build-from-json.nix

### DIFF
--- a/lib/build-from-json.nix
+++ b/lib/build-from-json.nix
@@ -176,7 +176,7 @@ let
             let
               base = buildRustCrateForPkgs cratePkgs;
             in
-            if defaultCrateOverrides != pkgs.defaultCrateOverrides then
+            if base ? override && defaultCrateOverrides != pkgs.defaultCrateOverrides then
               base.override { defaultCrateOverrides = defaultCrateOverrides; }
             else
               base;


### PR DESCRIPTION
build-from-json.nix calls `.override { defaultCrateOverrides = ...; }` on
the function returned by `buildRustCrateForPkgs cratePkgs`. The default
hook returns `pkgs.buildRustCrate`, which is `lib.makeOverridable` and so
carries `.override`. But the hook exists precisely so callers can replace
it, and a common shape for the replacement is a plain `crate_: drv`
wrapper (e.g. one that appends `extraRustcOpts` for coverage
instrumentation). A plain function has no `.override`, so the existing
code crashes with `attribute 'override' missing`.

The current guard, `defaultCrateOverrides != pkgs.defaultCrateOverrides`,
is a value-equality check. The only way for a caller with a non-overridable
wrapper to avoid the crash is to pass `pkgs.defaultCrateOverrides` back in
verbatim so the comparison fails — a non-obvious coupling between the
*value* of one argument and whether a *method* is required on the result
of another.

Add `base ? override` to the guard so `.override` is only called when it
actually exists. Callers who pass only a custom `defaultCrateOverrides`
(and leave `buildRustCrateForPkgs` at its default) are unaffected — that
path returns an overridable function and continues to honor the override.
Callers who wrap `buildRustCrateForPkgs` are expected to bake their own
`defaultCrateOverrides` into the wrapper, so silently skipping the outer
`.override` is the correct behavior, not a silent loss of configuration.
