### PR TITLE
feat: accept per-member src overrides in build-from-json.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,16 @@ in {
 }
 ```
 
-The consumer accepts two optional arguments for customisation:
+The consumer accepts three optional arguments for customisation:
 
 - `buildRustCrateForPkgs` — override the `buildRustCrate` used (e.g. for a
   custom toolchain)
 - `defaultCrateOverrides` — per-crate build fixups, same as the existing
   `Cargo.nix` workflow
+- `memberSrcs` — attrset from crate name to a per-crate `src` store path,
+  used instead of `src + "/<member dir>"` for local path crates. Build the
+  values with `lib.fileset.toSource` so editing one member only rehashes
+  that member's derivation instead of the whole workspace.
 
 ## Documentation
 

--- a/lib/build-from-json.nix
+++ b/lib/build-from-json.nix
@@ -12,6 +12,14 @@
 #       resolvedJson = ./Cargo.json;
 #     };
 #   in cargoNix.workspaceMembers.my-crate.build
+#
+# To keep workspace-member derivations hash-isolated from each other (so
+# editing one crate does not rebuild all of them), pass `memberSrcs`: an
+# attrset from crate name to a per-crate store path whose contents match
+# what `src + "/<member dir>"` would contain. Local path crates not in the
+# map fall back to `src + "/<member dir>"`. Build per-crate sources with
+# `lib.fileset.toSource` so a change in one crate only rehashes that
+# crate's source.
 
 { pkgs ? import <nixpkgs> { }
 , lib ? pkgs.lib
@@ -20,6 +28,12 @@
   src
 , # Path to the pre-resolved JSON file
   resolvedJson
+, # Optional: per-member src overrides, keyed by crate name. When a local
+  # crate's name is present here, that store path is used as its `src`
+  # instead of `src + "/<source.path>"`. Pass content-identical sources
+  # (e.g. `lib.fileset.toSource` rooted at the member dir) so editing one
+  # member rehashes only that member's derivation, not the whole workspace.
+  memberSrcs ? { }
 , # Optional: function to create buildRustCrate for a given pkgs
   buildRustCrateForPkgs ? pkgs: pkgs.buildRustCrate
 , # Optional: default crate overrides
@@ -40,7 +54,8 @@ let
       relPath = if source == null then "." else source.path or ".";
     in
     if sourceType == "local" then
-      if relPath == "." then src else src + "/${relPath}"
+      memberSrcs.${crateInfo.crateName}
+        or (if relPath == "." then src else src + "/${relPath}")
     else if sourceType == "crates-io" then
       pkgs.fetchurl
         {

--- a/tests.nix
+++ b/tests.nix
@@ -789,6 +789,32 @@ in
           grep 'write_output_file' $out/test-list.log
         '';
       };
+
+    # Verify `memberSrcs` overrides a local crate's resolved `src` and
+    # that omitting it (or naming a different crate) keeps the existing
+    # `src + "/<member dir>"` behaviour. Eval-only: never builds a crate.
+    json_member_srcs =
+      let
+        workspaceSrc = ./sample_projects/integration_test;
+        overrideSrc = pkgs.runCommandNoCCLocal "json-member-srcs-override" { } "mkdir $out";
+        mkCargoNix = args: import ./lib/build-from-json.nix ({
+          inherit pkgs;
+          src = workspaceSrc;
+          resolvedJson = workspaceSrc + "/Cargo.json";
+        } // args);
+        defaultSrc = (mkCargoNix { }).rootCrate.build.src;
+        overriddenSrc = (mkCargoNix { memberSrcs.integration_test = overrideSrc; }).rootCrate.build.src;
+        missSrc = (mkCargoNix { memberSrcs.some_other_crate = overrideSrc; }).rootCrate.build.src;
+      in
+      pkgs.runCommandNoCCLocal "json_member_srcs" { } ''
+        echo === default omits memberSrcs: src is the workspace root
+        [ "${defaultSrc}" = "${workspaceSrc}" ]
+        echo === matching key replaces src
+        [ "${overriddenSrc}" = "${overrideSrc}" ]
+        echo === non-matching key falls back to default
+        [ "${missSrc}" = "${defaultSrc}" ]
+        touch $out
+      '';
   }
   // rec {
     #


### PR DESCRIPTION
build-from-json.nix resolves every local workspace member as a subpath
of the single `src` store path. Editing any file anywhere in the
workspace rehashes `src`, which invalidates every member's derivation
and defeats crate2nix's per-crate caching: touching one crate's
main.rs rebuilds the whole workspace.

Add a `memberSrcs ? { }` parameter, an attrset keyed by crate name.
When a local crate's name is present, that store path is used as its
`src` instead of `src + "/<source.path>"`. Members not in the map keep
the existing behavior. Callers build per-member sources with
`lib.fileset.toSource` (or equivalent) so each member derivation only
depends on the hash of its own files; an edit in one crate then
rebuilds only that crate and its reverse dependencies.

Previously this required intercepting `crate.src` inside
`buildRustCrateForPkgs`, which reaches into buildRustCrate internals
and duplicates the source-resolution logic here.
