### PR TITLE
feat: add hakariStubCrates option to build-from-json.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,16 @@ in {
 }
 ```
 
-The consumer accepts two optional arguments for customisation:
+The consumer accepts three optional arguments for customisation:
 
 - `buildRustCrateForPkgs` — override the `buildRustCrate` used (e.g. for a
   custom toolchain)
 - `defaultCrateOverrides` — per-crate build fixups, same as the existing
   `Cargo.nix` workflow
+- `hakariStubCrates` — list of [cargo-hakari](https://docs.rs/cargo-hakari) workspace-hack
+  crate names whose dependencies should be dropped. crate2nix bakes the unified feature set
+  into every dependency at lock time, so the workspace-hack crate's own dependency closure
+  is dead weight; stubbing it keeps per-crate builds small.
 
 ## Documentation
 

--- a/lib/build-from-json.nix
+++ b/lib/build-from-json.nix
@@ -24,6 +24,14 @@
   buildRustCrateForPkgs ? pkgs: pkgs.buildRustCrate
 , # Optional: default crate overrides
   defaultCrateOverrides ? pkgs.defaultCrateOverrides
+, # Optional: names of cargo-hakari workspace-hack crates whose dependencies
+  # should be dropped. cargo-hakari's job is feature unification at lock time;
+  # crate2nix already bakes the unified feature set into each dependency's
+  # `resolvedDefaultFeatures`, so building the workspace-hack crate's (often
+  # 100+) dependencies just to produce empty rlibs is pure overhead. Listing
+  # the crate here keeps per-crate targets from dragging in the full workspace
+  # dependency closure.
+  hakariStubCrates ? [ ]
 ,
 }:
 
@@ -217,19 +225,31 @@ let
       # them must be built for that platform (not just proc-macros).
       buildDepDrv = dep: self.build.crates.${dep.packageId};
 
+      # cargo-hakari workspace-hack crates exist only to unify feature
+      # selection at lock time. crate2nix bakes the unified feature set into
+      # each dependency's `resolvedDefaultFeatures`, so the workspace-hack
+      # crate's own dependency closure is dead weight: empty rlibs that
+      # drag the full workspace closure into every per-crate target. Drop
+      # the deps here, before they reach buildRustCrate; buildRustCrate
+      # threads dependencies/buildDependencies through makeOverridable
+      # defaults from the crate record, so a crateOverride can't replace
+      # them later.
+      isHakariStub = lib.elem crateInfo.crateName hakariStubCrates;
+
       # Dev-deps only merge for the crate under test, not its transitive deps.
       # This mirrors the template mode's `packageId == rootPackageId` guard.
       devDeps = lib.optionals isTestRoot (crateInfo.devDependencies or [ ]);
-      normalDeps = (crateInfo.dependencies or [ ]) ++ devDeps;
+      normalDeps =
+        if isHakariStub then [ ]
+        else (crateInfo.dependencies or [ ]) ++ devDeps;
+      rawBuildDeps =
+        if isHakariStub then [ ]
+        else crateInfo.buildDependencies or [ ];
 
       dependencies = map depDrv (filterDeps normalDeps targetPlatform);
-      buildDependencies = map buildDepDrv (filterDeps (crateInfo.buildDependencies or [ ]) targetPlatform);
+      buildDependencies = map buildDepDrv (filterDeps rawBuildDeps targetPlatform);
 
-      allDeps = filterDeps
-        (
-          normalDeps ++ (crateInfo.buildDependencies or [ ])
-        )
-        targetPlatform;
+      allDeps = filterDeps (normalDeps ++ rawBuildDeps) targetPlatform;
       renamedDeps = lib.filter (d: d ? rename && d.rename != null) allDeps;
       crateRenames =
         let


### PR DESCRIPTION
cargo-hakari's workspace-hack pattern depends on every transitive
dependency with the unified feature set so cargo's lock-time feature
unification stays consistent across the workspace. crate2nix reads the
lockfile directly and bakes the resolved feature set into each crate's
resolvedDefaultFeatures, so every leaf already builds with the unified
set. Building the workspace-hack crate's own (often 100+) dependencies
just produces empty rlibs that drag the full workspace dependency
closure into every per-crate target.

Add an opt-in hakariStubCrates parameter listing crate names whose
dependencies and buildDependencies are dropped before they reach
buildRustCrate. This must happen in buildCrate rather than via a
crateOverride: buildRustCrate threads dependencies/buildDependencies
through makeOverridable defaults from the original crate record, so a
crateOverride can never replace them.
