### PR TITLE
feat: pass isHost flag to buildRustCrateForPkgs in build-from-json.nix

### DIFF
--- a/lib/build-from-json.nix
+++ b/lib/build-from-json.nix
@@ -166,20 +166,59 @@ let
   # Build a crate graph. When testRootPackageId is non-null, the crate with
   # that ID gets its devDependencies merged into dependencies and buildTests
   # set so buildRustCrate compiles test targets instead of lib/bin.
+  #
+  # Two graphs are resolved: the *target* graph (`self.crates` — rlib deps
+  # and workspace members, what the workspace links against) and the *host*
+  # graph (`self.build` — build scripts, proc-macros, and their transitive
+  # dependency closures, run on the build host). Both call
+  # `buildRustCrateForPkgs`, but on a non-cross build `pkgs.buildPackages
+  # == pkgs`, so `cratePkgs` alone cannot tell the consumer which graph a
+  # crate belongs to.
+  #
+  # Surface the distinction via an extra curried `{ isHost }` argument
+  # between `cratePkgs` and the crate record. This is *opt-in*: it is only
+  # supplied when the function returned by `buildRustCrateForPkgs cratePkgs`
+  # declares `isHost` in its argument pattern, i.e. when the consumer's
+  # function has the shape
+  #
+  #   buildRustCrateForPkgs = pkgs: { isHost ? false }: crate_: pkgs.buildRustCrate (crate_ // { ... });
+  #
+  # A bare `pkgs: crate_: drv` consumer — including the default
+  # `pkgs.buildRustCrate` — has empty `functionArgs` on the returned
+  # function, so the extra argument is never applied and the call site
+  # is byte-for-byte identical to before. Because the flag travels as a
+  # curried argument and never lands on the crate record, it cannot leak
+  # into `mkDerivation` (via `extraDerivationAttrs`) and perturb existing
+  # derivation hashes for consumers that don't opt in.
+  #
+  # Use case: tools that compile target crates with a custom rustc driver
+  # and flags (kani-compiler, miri, coverage instrumentation) but need
+  # host artifacts to compile with vanilla rustc — proc-macros and build
+  # scripts are loaded/executed by rustc at compile time and cannot carry
+  # the custom flags. Mirrors cargo's `-Z target-applies-to-host`.
   mkBuiltByPackageIdByPkgs =
     { testRootPackageId ? null }:
     let
       go =
-        cratePkgs:
+        cratePkgs: isHost:
         let
           buildRustCrate =
             let
               base = buildRustCrateForPkgs cratePkgs;
+              withOverrides =
+                if defaultCrateOverrides != pkgs.defaultCrateOverrides then
+                  base.override { defaultCrateOverrides = defaultCrateOverrides; }
+                else
+                  base;
+              # Opt-in detection: a consumer that wants the host/target
+              # distinction declares `{ isHost ? false }:` as the *next*
+              # curried argument after `cratePkgs`. `functionArgs` of a
+              # positional lambda (`crate_: drv`) is `{}`, so the default
+              # `pkgs.buildRustCrate` and any non-opted-in wrapper fall
+              # through to the legacy shape unchanged.
+              wantsIsHost = (lib.functionArgs base) ? isHost;
             in
-            if defaultCrateOverrides != pkgs.defaultCrateOverrides then
-              base.override { defaultCrateOverrides = defaultCrateOverrides; }
-            else
-              base;
+            if wantsIsHost then withOverrides { inherit isHost; } else withOverrides;
 
           self = {
             crates = lib.mapAttrs
@@ -187,12 +226,12 @@ let
                 packageId: _: buildCrate self cratePkgs buildRustCrate testRootPackageId packageId
               )
               resolved.crates;
-            build = go cratePkgs.buildPackages;
+            build = go cratePkgs.buildPackages true;
           };
         in
         self;
     in
-    go pkgs;
+    go pkgs false;
 
   buildCrate =
     self: cratePkgs: buildRustCrate: testRootPackageId: packageId:


### PR DESCRIPTION
Allows consumers to distinguish **host** crates (build scripts, proc-macros, and their transitive dependency closures) from **target** crates (rlib deps and workspace members) when using `lib/build-from-json.nix`.

## Motivation

Tools like Kani (Rust verifier) and Miri compile target crates with a custom rustc driver (e.g. `kani-compiler`) and custom flags (`--cfg=kani`, `-C panic=abort`, custom `--sysroot`), but host artifacts must compile with vanilla rustc — proc-macros and build scripts are loaded/executed by rustc at compile time and cannot carry the modified flags. `cargo kani` solves this with cargo's `-Z target-applies-to-host` mechanism.

`build-from-json.nix` already resolves separate host and target graphs (`self.crates` vs `self.build`), but it does not surface the distinction to `buildRustCrateForPkgs`: on a non-cross build `pkgs.buildPackages == pkgs`, so the consumer cannot tell which graph a crate belongs to from `cratePkgs` alone.

## Change

Thread an `isHost` boolean through the recursion in `mkBuiltByPackageIdByPkgs` and surface it to the consumer as an extra curried `{ isHost }` argument between `cratePkgs` and the crate record. Consumers opt in by declaring it in their function pattern:

```nix
buildRustCrateForPkgs = pkgs: { isHost ? false }: crate_:
  pkgs.buildRustCrate (crate_ // {
    extraRustcOpts = if isHost then [ ] else myCustomFlags;
  });
```

Detection uses `lib.functionArgs` on the function returned by `buildRustCrateForPkgs cratePkgs`. A bare `pkgs: crate_: drv` consumer — including the default `pkgs.buildRustCrate` — has empty `functionArgs` and falls through unchanged.

## Backward compatibility

The flag is delivered as a curried argument, **not** an attribute on the crate record. It therefore never reaches `mkDerivation` through `extraDerivationAttrs` and cannot perturb derivation hashes for consumers that do not opt in. Verified locally on `sample_projects/integration_test/Cargo.json`: default-consumer `rootCrate.build.drvPath` and `.buildTests.drvPath` are byte-for-byte identical before and after this change.

## Use case

Companion change in `rio-build`: a fifth crate2nix tree where `buildRustCrateForPkgs` applies `globalExtraRustcOpts` only when `!isHost`, enabling Kani verification with per-crate caching while proc-macro crates still produce loadable `.so` files.