### PR TITLE
test: set dontInstall

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -3340,6 +3340,8 @@ rec {
 
             inherit testCrateFlags;
 
+            dontInstall = true;
+
             buildInputs = testInputs;
 
             buildPhase = ''

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -176,6 +176,8 @@ rec {
 
             inherit testCrateFlags;
 
+            dontInstall = true;
+
             buildInputs = testInputs;
 
             buildPhase = ''

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1539,6 +1539,8 @@ rec {
 
             inherit testCrateFlags;
 
+            dontInstall = true;
+
             buildInputs = testInputs;
 
             buildPhase = ''

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -708,6 +708,8 @@ rec {
 
             inherit testCrateFlags;
 
+            dontInstall = true;
+
             buildInputs = testInputs;
 
             buildPhase = ''

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -310,6 +310,8 @@ rec {
 
             inherit testCrateFlags;
 
+            dontInstall = true;
+
             buildInputs = testInputs;
 
             buildPhase = ''


### PR DESCRIPTION
Using `buildPhase` means that `stdenvNoCC.mkDerivation` still runs the other default phases, which in the default mode of operation can fail if a Makefile happens to exist in the directory the tests are ran from. Since we are only interested in running the tests with rustc, we can set `dontInstall` to true to prevent potential Makefile usage.