### PR TITLE
fix: don't synthesize a phantom `default` feature for crates that declare none

### DIFF
--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -584,17 +584,40 @@ rec {
       assert (builtins.isBool runTests);
       let
         crateConfig = crateConfigs."${packageId}" or (builtins.throw "Package not found: ${packageId}");
-        # Cargo treats `default-features = true` on a crate that declares no
-        # `default` feature as a no-op (it enables nothing). crate2nix otherwise
-        # keeps the synthesized "default" — from a default-features-on dependency
-        # edge or from the root's default `rootFeatures = [ "default" ]` — and
-        # stamps a phantom `--cfg feature="default"`, forking the crate's
-        # derivation (different `-C metadata`) from any path that reaches it
-        # without "default". Strip it here, the single point every crate's
-        # feature set flows through, so both cases are covered at once.
+        # crate2nix synthesizes "default" for a crate whenever it is reached with
+        # default features on — from a default-features-on dependency edge or from
+        # the root's default `rootFeatures = [ "default" ]` — and stamps a
+        # `--cfg feature="default"` that changes the crate's `-C metadata` hash.
+        # When the crate is *also* reached without "default", it forks into two
+        # derivations and the fork propagates to everything downstream. We
+        # reconcile the requested feature set with what Cargo actually resolves,
+        # which depends on whether — and how — the crate declares `default`:
+        #
+        #   1. Declares a non-empty `default = [ ... ]`
+        #      (`crateConfig.features ? "default"`): Cargo resolves it normally
+        #      and crate2nix already matches — pass `features` through untouched.
+        #
+        #   2. Declares an *empty* `default = []`: crate2nix omits an empty
+        #      default from `crateConfig.features` (so case 1's test misses it),
+        #      but records it in `crateConfig.resolvedDefaultFeatures`. "default"
+        #      enables no extra features, yet the crate's source may still gate on
+        #      `cfg(feature = "default")` (e.g. document-features carries
+        #      `#[cfg(not(feature = "default"))] compile_error!(...)`), so we must
+        #      NOT strip it. `resolvedDefaultFeatures` is Cargo's single global
+        #      resolution, so we force "default" on in every closure that reaches
+        #      the crate: the cfg stays satisfied and the derivation stays unique
+        #      (consistently-on dedups exactly as consistently-off would).
+        #
+        #   3. Declares no `default` at all (absent from both `features` and
+        #      `resolvedDefaultFeatures`): Cargo never sets `cfg(feature =
+        #      "default")`, so the synthesized "default" is a phantom — strip it,
+        #      collapsing the fork. `default-features = true` on such a crate is a
+        #      Cargo no-op.
         requestedFeatures =
           if (crateConfig.features or { }) ? "default" then
             features
+          else if builtins.elem "default" (crateConfig.resolvedDefaultFeatures or [ ]) then
+            features ++ [ "default" ]
           else
             lib.filter (f: f != "default") features;
         expandedFeatures = expandFeatures (crateConfig.features or { }) requestedFeatures;

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -584,7 +584,20 @@ rec {
       assert (builtins.isBool runTests);
       let
         crateConfig = crateConfigs."${packageId}" or (builtins.throw "Package not found: ${packageId}");
-        expandedFeatures = expandFeatures (crateConfig.features or { }) features;
+        # Cargo treats `default-features = true` on a crate that declares no
+        # `default` feature as a no-op (it enables nothing). crate2nix otherwise
+        # keeps the synthesized "default" — from a default-features-on dependency
+        # edge or from the root's default `rootFeatures = [ "default" ]` — and
+        # stamps a phantom `--cfg feature="default"`, forking the crate's
+        # derivation (different `-C metadata`) from any path that reaches it
+        # without "default". Strip it here, the single point every crate's
+        # feature set flows through, so both cases are covered at once.
+        requestedFeatures =
+          if (crateConfig.features or { }) ? "default" then
+            features
+          else
+            lib.filter (f: f != "default") features;
+        expandedFeatures = expandFeatures (crateConfig.features or { }) requestedFeatures;
         enabledFeatures = enableFeatures (crateConfig.dependencies or [ ]) expandedFeatures;
         depWithResolvedFeatures =
           dependency:

--- a/crate2nix/templates/nix/crate2nix/tests/packageFeatures.nix
+++ b/crate2nix/templates/nix/crate2nix/tests/packageFeatures.nix
@@ -53,6 +53,19 @@ let
       features = { };
     };
 
+    # A crate that declares no `default` feature, depended on with default
+    # features left on (the implicit default for the edge). Cargo enables
+    # nothing in this case, so neither should crate2nix.
+    "pkg_no_default_root" = {
+      crateName = "no_default_root";
+      dependencies = [
+        {
+          name = "id3";
+          packageId = "pkg_id3";
+        }
+      ];
+    };
+
     "pkg_numtest" = {
       crateName = "numtest";
       dependencies = [
@@ -106,7 +119,8 @@ in
   testNumTestDependencies = {
     expr = packageFeatures "pkg_numtest" [ "default" ];
     expected = {
-      "pkg_numtest" = [ "default" ];
+      # pkg_numtest declares no `default` feature → "default" enables nothing.
+      "pkg_numtest" = [ ];
       "pkg_num" = [ "default" "num-bigint" "num-bigint/std" "std" ];
       "pkg_num_bigint" = [ "std" ];
     };
@@ -129,7 +143,9 @@ in
   testRootPackage = {
     expr = packageFeatures "pkg_root" [ "default" ];
     expected = {
-      "pkg_root" = [ "default" ];
+      # pkg_root declares no `default` feature, so the requested "default"
+      # enables nothing — matching `cargo build` (previously [ "default" ]).
+      "pkg_root" = [ ];
       "pkg_id1" = [ "default" ];
       "pkg_id3" = [ ];
     };
@@ -138,9 +154,25 @@ in
   testRootPackageWithOptional = {
     expr = packageFeatures "pkg_root" [ "default" "optional_id2" ];
     expected = {
-      "pkg_root" = [ "default" "optional_id2" ];
+      # "default" dropped (pkg_root declares none); "optional_id2" is real.
+      "pkg_root" = [ "optional_id2" ];
       "pkg_id1" = [ "default" ];
-      "pkg_id2" = [ "default" ];
+      # pkg_id2 declares no `default` feature, so `default-features = true` on
+      # the edge enables nothing — matching Cargo (previously [ "default" ]).
+      "pkg_id2" = [ ];
+      "pkg_id3" = [ ];
+    };
+  };
+
+  # Regression test: requesting "default" on a crate that declares no `default`
+  # feature must not synthesize a phantom "default" — whether it arrives via a
+  # default-features-on dependency edge (pkg_id3 below) or as a root feature
+  # (testRootPackage above). Otherwise the crate forks from any path that
+  # reaches it without "default".
+  testDefaultFeaturesNoOpWhenUndeclared = {
+    expr = packageFeatures "pkg_no_default_root" [ ];
+    expected = {
+      "pkg_no_default_root" = [ ];
       "pkg_id3" = [ ];
     };
   };

--- a/crate2nix/templates/nix/crate2nix/tests/packageFeatures.nix
+++ b/crate2nix/templates/nix/crate2nix/tests/packageFeatures.nix
@@ -66,6 +66,33 @@ let
       ];
     };
 
+    # A crate that declares an *empty* `default = []`. crate2nix omits the empty
+    # default from `features`, but Cargo still resolves it — recorded in
+    # `resolvedDefaultFeatures`. Unlike a crate with no `default` at all, its
+    # source may gate on `cfg(feature = "default")` (e.g. document-features
+    # carries `#[cfg(not(feature = "default"))] compile_error!(...)`), so
+    # "default" must stay enabled even when the crate is reached via a
+    # `default-features = false` edge.
+    "pkg_empty_default" = {
+      crateName = "empty_default";
+      features = { };
+      resolvedDefaultFeatures = [ "default" ];
+    };
+
+    # Reaches pkg_empty_default through a `default-features = false` edge, so
+    # nothing requests "default" — yet the empty (but resolved) default must
+    # still come back on.
+    "pkg_empty_default_off_root" = {
+      crateName = "empty_default_off_root";
+      dependencies = [
+        {
+          name = "empty_default";
+          packageId = "pkg_empty_default";
+          usesDefaultFeatures = false;
+        }
+      ];
+    };
+
     "pkg_numtest" = {
       crateName = "numtest";
       dependencies = [
@@ -174,6 +201,21 @@ in
     expected = {
       "pkg_no_default_root" = [ ];
       "pkg_id3" = [ ];
+    };
+  };
+
+  # Regression test for the *empty* `default = []` case: a crate that declares an
+  # empty default (omitted from `features`, but present in
+  # `resolvedDefaultFeatures`) must keep "default" enabled even when every edge
+  # reaching it disables default features. Its source may gate on
+  # `cfg(feature = "default")` (e.g. document-features' compile_error!), so
+  # stripping "default" — as we do for a crate that declares no default at all —
+  # would miscompile it and re-fork it from default-on paths.
+  testEmptyDefaultKeptWhenEdgeDisablesIt = {
+    expr = packageFeatures "pkg_empty_default_off_root" [ ];
+    expected = {
+      "pkg_empty_default_off_root" = [ ];
+      "pkg_empty_default" = [ "default" ];
     };
   };
 


### PR DESCRIPTION
Fixes #485.

## Problem

`mergePackageFeatures` resolves every crate's features via:

```nix
expandedFeatures = expandFeatures (crateConfig.features or { }) features;
```

where `features` is the requested set — a dependency's resolved features (which include `"default"` for any `usesDefaultFeatures` edge, via `dependencyFeatures`) or the root's `rootFeatures` (default `[ "default" ]`). It keeps `"default"` even when the target crate **declares no `default` feature**.

Cargo treats requesting `default` on such a crate as a no-op (it enables nothing). crate2nix instead stamps a phantom `--cfg feature="default"`, which changes the crate's `-C metadata` hash. So a crate reached both **with** and **without** `"default"` — a default-on dep edge vs a `default-features = false` edge, or a root build vs a dependency — forks into **two derivations**, and the fork propagates to everything downstream. Crates with no `[features]` table at all (e.g. `equivalent`) are the clearest trigger; see #485 for a minimal repro (a feature-less `leaf` crate compiled twice).

## Fix

Reconcile the requested feature set at this single chokepoint with what Cargo actually resolves. There are **three** cases, not two, because crate2nix omits an *empty* `default = []` from `crateConfig.features` — so the simple `? "default"` test cannot tell "declares no default" apart from "declares an empty default":

```nix
requestedFeatures =
  if (crateConfig.features or { }) ? "default" then
    # 1. Non-empty `default = [ ... ]`: Cargo resolves it normally; pass through.
    features
  else if builtins.elem "default" (crateConfig.resolvedDefaultFeatures or [ ]) then
    # 2. Empty `default = []`: omitted from `features` but recorded in
    #    `resolvedDefaultFeatures`. Enables nothing, but the crate's source may
    #    gate on `cfg(feature = "default")`, so keep it — force it on everywhere.
    features ++ [ "default" ]
  else
    # 3. No `default` at all: strip the phantom, collapsing the fork.
    lib.filter (f: f != "default") features;
expandedFeatures = expandFeatures (crateConfig.features or { }) requestedFeatures;
```

Case 2 is the important correction. An earlier revision of this PR stripped `"default"` whenever it was absent from `crateConfig.features`, on the assumption that an empty `default = []` is always a pure no-op. It isn't: [`document-features`](https://docs.rs/document-features) declares `default = []` yet carries `#[cfg(not(feature = "default"))] compile_error!(...)`, so stripping `"default"` makes it fail to compile under crate2nix while it builds fine under Cargo (which leaves default features on). Forcing the empty default **on** rather than off both satisfies the cfg and keeps the derivation unique — `resolvedDefaultFeatures` is Cargo's single global resolution, so the feature set is identical in every closure that reaches the crate, and consistently-on dedups exactly as consistently-off would.

## Tests

Updates the `packageFeatures` tests whose expectations encoded the old behavior — a crate that declares no `default` feature, requested with `"default"` (via a dep edge **or** as a root feature), now resolves without it. Adds a regression test for case 2: a crate with an empty (resolved) default reached only through a `default-features = false` edge keeps `"default"`. `lib.runTests` over `templates/nix/crate2nix/tests` returns `[]` (all pass).

Verified end-to-end against the #485 repro (the two `leaf` derivations collapse to one), against `document-features` (it compiles again), and in a large real workspace (the whole sqlx stack and domain layer de-duplicate, standalone binaries stop forking from their in-dependency copies, and a drv-count shows zero same-name+version forks).