### PR TITLE
fix: give each local crate its own src store path

### DIFF
--- a/lib/build-from-json.nix
+++ b/lib/build-from-json.nix
@@ -40,7 +40,11 @@ let
       relPath = if source == null then "." else source.path or ".";
     in
     if sourceType == "local" then
-      if relPath == "." then src else src + "/${relPath}"
+      builtins.path
+        {
+          name = "${crateInfo.crateName}-src";
+          path = if relPath == "." then src else src + "/${relPath}";
+        }
     else if sourceType == "crates-io" then
       pkgs.fetchurl
         {


### PR DESCRIPTION
resolveSrc used a bare `src + "/${relPath}"` subpath of the single workspace source store path. A subpath reference depends on the entire parent store path, so editing any one file anywhere in the workspace changed every crate's src hash and rebuilt the whole graph.

Instead we here use `builtins.path` so each crate's src is re-imported as its own store path, hashed only on that crate's own files. Akin to `Cargo.nix`'s behavior.